### PR TITLE
allow to set path to via cmake.cmakePath config

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
                         "NMake Makefiles"
                     ],
                     "description": "The preferred CMake generator(s) to use when configuring (tried in order of listing)"
+                },
+                "cmake.cmakePath": {
+                    "type": "string",
+                    "default": "cmake",
+                    "description": "The path to CMake generator executable"
                 }
             }
         },

--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -390,7 +390,7 @@ export class CMakeTools {
     public execute(args: string[]): Promise<Number> {
         return new Promise<Number>((resolve, _) => {
             console.info('Execute cmake with arguments:', args);
-            const pipe = proc.spawn('cmake', args);
+            const pipe = proc.spawn(this.config<string>('cmakePath', 'cmake'), args);
             this.currentChildProcess = pipe;
             const status = msg => vscode.window.setStatusBarMessage(msg, 4000);
             status('Executing CMake...');


### PR DESCRIPTION
Sometimes you might not have cmake in the path, having such an option is convenient and allows to use and test different cmake versions without modifying the path.