### PR TITLE
add support for Visual Studio Win64/ARM generators

### DIFF
--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -493,13 +493,16 @@ export class CMakeTools {
                 }
             }[gen];
             if (delegate === undefined) {
+                const vsMatcher = /^Visual Studio (\d{2}) (\d{4})($|\sWin64$|\sARM$)/;
+                if (vsMatcher.test(gen) && process.platform === 'win32')
+                    return gen;
                 vscode.window.showErrorMessage('Unknown CMake generator "' + gen + '"');
                 continue;
             }
             if (await delegate())
                 return gen;
             else
-                console.log('Genereator "' + gen + '" is not supported');
+                console.log('Generator "' + gen + '" is not supported');
         }
         return null;
     }


### PR DESCRIPTION
As per https://cmake.org/cmake/help/v3.5/manual/cmake-generators.7.html#visual-studio-generators

support all generators starting from 2005 (due to regexp check) :)
this way no need for compilers/make-tools in the path
