### PR TITLE
allow configuration of the source directory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
                     "default": "${workspaceRoot}/build",
                     "description": "The directory where CMake build files will go"
                 },
+                "cmake.sourceDirectory": {
+                    "type": "string",
+                    "default": "${workspaceRoot}",
+                    "description": "The directory of the root CMakeLists.txt file"
+                },
                 "cmake.saveBeforeBuild": {
                     "type": "boolean",
                     "default": true,

--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -499,7 +499,8 @@ export class CMakeTools {
     }
 
     public get sourceDir(): string {
-        return vscode.workspace.rootPath;
+        const source_dir = this.config<string>('sourceDirectory');
+        return source_dir.replace('${workspaceRoot}', vscode.workspace.rootPath);
     }
 
     public get mainListFile(): string {


### PR DESCRIPTION
Handy for multi-language projects where your workspace root and the location of the root cmake lists file may differ.