### PR TITLE
Fix GNULD error regex parsing

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -16,7 +16,7 @@ export interface RawDiagnostic {
 
 
 export function parseGCCDiagnostic(line: string): Maybe<RawDiagnostic> {
-    const gcc_re = /^(.*):(\d+):(\d+):\s+(?:fatal )?(warning|error|note):\s+(.*)$/;
+    const gcc_re = /^(.*):(\d+):(\d+):\s+(?:fatal )?(.*):\s+(.*)$/;
     const res = gcc_re.exec(line);
     if (!res)
         return null;
@@ -36,7 +36,7 @@ export function parseGCCDiagnostic(line: string): Maybe<RawDiagnostic> {
 }
 
 export function parseGNULDDiagnostic(line): Maybe<RawDiagnostic> {
-    const ld_re = /^(.*):(\d+):(\d+):\s+(.*)$/;
+    const ld_re = /^(.*):(\d+)\s+:\s+(.*)$/;
     const res = ld_re.exec(line);
     if (!res) {
         return null;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -36,7 +36,7 @@ export function parseGCCDiagnostic(line: string): Maybe<RawDiagnostic> {
 }
 
 export function parseGNULDDiagnostic(line): Maybe<RawDiagnostic> {
-    const ld_re = /^(.*):(\d+):\s+(.*)$/;
+    const ld_re = /^(.*):(\d+):(\d+):\s+(.*)$/;
     const res = ld_re.exec(line);
     if (!res) {
         return null;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -16,7 +16,7 @@ export interface RawDiagnostic {
 
 
 export function parseGCCDiagnostic(line: string): Maybe<RawDiagnostic> {
-    const gcc_re = /^(.*):(\d+):(\d+):\s+(?:fatal )?(.*):\s+(.*)$/;
+    const gcc_re = /^(.*):(\d+):(\d+):\s+(?:fatal )?(\w*)(?:\sfatale)?\s?:\s+(.*)/;
     const res = gcc_re.exec(line);
     if (!res)
         return null;
@@ -36,7 +36,7 @@ export function parseGCCDiagnostic(line: string): Maybe<RawDiagnostic> {
 }
 
 export function parseGNULDDiagnostic(line): Maybe<RawDiagnostic> {
-    const ld_re = /^(.*):(\d+)\s+:\s+(.*)$/;
+    const ld_re = /^(.*):(\d+)\s?:\s+(.*)$/;
     const res = ld_re.exec(line);
     if (!res) {
         return null;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -136,6 +136,48 @@ suite("Utility tests", () => {
             assert(path.posix.isAbsolute(diag.file));
         }
     });
+    test('Parsing fatal error diagnostics in french', () => {
+        const line = '/home/romain/TL/test/base.c:2:21: erreur fatale : bonjour.h : Aucun fichier ou dossier de ce type';
+        const diag = diagnostics.parseGCCDiagnostic(line);
+        assert(diag);
+        if (diag) {
+            assert.strictEqual(diag.line, 1);
+            assert.strictEqual(diag.message, 'bonjour.h : Aucun fichier ou dossier de ce type');
+            assert.strictEqual(diag.column, 20);
+            assert.strictEqual(diag.file, '/home/romain/TL/test/base.c');
+            assert.strictEqual(diag.severity, 'erreur');
+            assert.strictEqual(path.posix.normalize(diag.file), diag.file);
+            assert(path.posix.isAbsolute(diag.file));
+        }
+    });
+    test('Parsing warning diagnostics', () => {
+        const line = "/some/path/here:4:26: warning: unused parameter 'data'";
+        const diag = diagnostics.parseGCCDiagnostic(line);
+        assert(diag);
+        if (diag) {
+            assert.strictEqual(diag.line, 3);
+            assert.strictEqual(diag.message, "unused parameter 'data'");
+            assert.strictEqual(diag.column, 25);
+            assert.strictEqual(diag.file, '/some/path/here');
+            assert.strictEqual(diag.severity, 'warning');
+            assert.strictEqual(path.posix.normalize(diag.file), diag.file);
+            assert(path.posix.isAbsolute(diag.file));
+        }
+    });
+    test('Parsing warning diagnostics in french', () => {
+        const line = '/home/romain/TL/test/base.c:155:2: attention : déclaration implicite de la fonction ‘create’';
+        const diag = diagnostics.parseGCCDiagnostic(line);
+        assert(diag);
+        if (diag) {
+            assert.strictEqual(diag.line, 154);
+            assert.strictEqual(diag.message, 'déclaration implicite de la fonction ‘create’');
+            assert.strictEqual(diag.column, 1);
+            assert.strictEqual(diag.file, '/home/romain/TL/test/base.c');
+            assert.strictEqual(diag.severity, 'attention');
+            assert.strictEqual(path.posix.normalize(diag.file), diag.file);
+            assert(path.posix.isAbsolute(diag.file));
+        }
+    });
     test('Parsing linker error', () => {
         const line = "/some/path/here:101: undefined reference to `some_function'";
         const diag = diagnostics.parseGNULDDiagnostic(line);
@@ -144,6 +186,19 @@ suite("Utility tests", () => {
             assert.strictEqual(diag.line, 100);
             assert.strictEqual(diag.message, "undefined reference to `some_function'");
             assert.strictEqual(diag.file, '/some/path/here');
+            assert.strictEqual(diag.severity, 'error');
+            assert.strictEqual(path.posix.normalize(diag.file), diag.file);
+            assert(path.posix.isAbsolute(diag.file));
+        }
+    });
+    test('Parsing linker error in french', () => {
+        const line = "/home/romain/TL/test/test_fa_tp4.c:9 : référence indéfinie vers « create_automaton_product56 »";
+        const diag = diagnostics.parseGNULDDiagnostic(line);
+        assert(diag);
+        if (diag) {
+            assert.strictEqual(diag.line, 8);
+            assert.strictEqual(diag.message, "référence indéfinie vers « create_automaton_product56 »");
+            assert.strictEqual(diag.file, '/home/romain/TL/test/test_fa_tp4.c');
             assert.strictEqual(diag.severity, 'error');
             assert.strictEqual(path.posix.normalize(diag.file), diag.file);
             assert(path.posix.isAbsolute(diag.file));


### PR DESCRIPTION
I could really use that fix... I haven't tested it !
The problem is that the :lineNumber is added to the file name so vscode can't open it when I check markers
Only Link, gcc is fine