### PR TITLE
Add config.ctestPath setting or infer ctest.exe

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,10 @@ export class ConfigurationReader {
     return this._readPrefixed<string>('cmakePath')!;
   }
 
+  get ctestPath(): string {
+    return this._readPrefixed<string>('ctestPath')!;
+  }
+
   get debugConfig(): any {
     return this._readPrefixed<any>('debugConfig');
   }

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -413,7 +413,7 @@ export class CTestController {
     this._channel.show();
     this._decorationManager.failingTestDecorations = [];
     const pr = util.execute(
-        'ctest',
+        config.ctestPath,
         [
           '-j' + config.numCTestJobs, '-C', configuration, '-T', 'test',
           '--output-on-failure'


### PR DESCRIPTION
This is not a proper yet complete pull request, rather a pilot for the feature request.
(I'm not seasoned with TypeScript at all, reading it for the first time, so not really capable to provide working and tested patch, I'm afraid.)

------

On Windows, I install CMake in typical location, in `C:\Program Files\CMake` but I don't add in the `bin` to `PATH`. Instead, I in `settings.json` I set
```
"cmake.cmakePath": "C:\\Program Files\\CMake\\bin\\cmake.exe"
```

Since `ctest.exe` is not available in the `PATH`, CMake Tools can't find it.
AFAICT, CMake Tools neither does try to infer `ctest.exe` location from the path to `cmake.exe`.

`CMake: Configure` command completes the configuration phase, but then VSCode displays `Error: span ctest ENOENT`.

Would it be possible to add `config.cmakePath` as I'm trying to visualise via this PR, or perhaps infer the location from the path to `cmake.exe`?
