### PR TITLE
Clarify cmake-variants.json is not created if one is not present

### DIFF
--- a/docs/build_variants.md
+++ b/docs/build_variants.md
@@ -12,7 +12,7 @@ in this manner.
 The most important part of the system is ``cmake-variants.json``, which encodes
 available build settings in such a way that they can be parsed and analyzed by
 automated tooling, as well as human users. Here is the default variants
-created by CMake Tools when one is not present in a project directory:
+configuration used by CMake Tools when one is not present in a project directory:
 
 ~~~json
 {


### PR DESCRIPTION
The presented variants configuration is just used as default
if the file does not exist.
Related to discussion in #136.