### PR TITLE
Updated README.md to add information about extension dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 powerful configure+build workflow for CMake-based projects within the
 Visual Studio Code editor.
 
-This extension itself *does not* provide language support for the CMake
-scripting language. For that I recommend [this extension](https://marketplace.visualstudio.com/items?itemName=twxs.cmake).
+Make you have [this dependency](https://marketplace.visualstudio.com/items?itemName=twxs.cmake) installed before using CMake Tools.
 
 ## What's New?
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 powerful configure+build workflow for CMake-based projects within the
 Visual Studio Code editor.
 
-Make you have [this dependency](https://marketplace.visualstudio.com/items?itemName=twxs.cmake) installed before using CMake Tools.
+Make sure you have [this dependency](https://marketplace.visualstudio.com/items?itemName=twxs.cmake) installed before using CMake Tools.
 
 ## What's New?
 


### PR DESCRIPTION
I never managed to get this extension working without installing the twxs.cmake extension as well. VS code listed twxs.cmake as a dependency for vscode-cmake-tools. That is the only reason I figured it out. It was not mentioned anywhere obvious in the documentation. Then again, I'm a TLDR person, perhaps it was possible to get this extension working without installing twxs?