### PR TITLE
Reuse CMake output windows.

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -218,6 +218,7 @@ const ENVIRONMENTS: EnvironmentProvider[] = [{
     const progfiles: string |undefined = process.env['programfiles(x86)'] || process.env['programfiles'];
     if (!progfiles) {
       log.error('Unable to find Program Files directory');
+      return [];
     }
     const vswhere = path.join(progfiles, 'Microsoft Visual Studio', 'Installer', 'vswhere.exe');
     if (!await async.exists(vswhere)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import * as api from './api';
 import { CMakeToolsWrapper } from './wrapper';
 import { log } from './logging';
+import { outputChannels } from "./util";
 
 export async function activate(context: vscode.ExtensionContext): Promise<CMakeToolsWrapper> {
     log.initialize(context);
@@ -47,5 +48,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<CMakeT
 
 // this method is called when your extension is deactivated
 export function deactivate() {
-    log.dispose();
+    outputChannels.dispose();
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import { outputChannels } from "./util";
 
 export type LogLevel = 'verbose' | 'normal' | 'minimal';
 export const LogLevel = {
@@ -14,7 +15,7 @@ export class Logger {
 
     private get logChannel(): vscode.OutputChannel {
         if (!this._logChannel) {
-            this._logChannel = vscode.window.createOutputChannel('CMake/Build');
+            this._logChannel = outputChannels.get('CMake/Build');
         }
         return this._logChannel!;
     }
@@ -30,13 +31,6 @@ export class Logger {
     public initialize(context: vscode.ExtensionContext) {
         vscode.workspace.onDidChangeConfiguration(this.onConfigurationChanged, this, context.subscriptions);
         this.onConfigurationChanged();
-    }
-
-    public dispose() {
-        if (this._logChannel) {
-            this._logChannel.dispose();
-            this._logChannel = undefined;
-        }
     }
 
     public error(message: string): void {


### PR DESCRIPTION
createOutputChannels were scattered across the extension which caused VSCode to create duplicate panes which were not accessible.

Fixes #175