### PR TITLE
Add option to build before run (buildBeforeRun)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ quick summary of options that can be tweaked, should you wish to do so:
 - ``cmake.saveBeforeBuild`` tells CMake Tools to save all open text documents
   after the build command is invoked, but before performing the build. This
   defaults to being _enabled_.
+- ``cmake.buildBeforeRun`` Always build the target before running.
 - ``cmake.preferredGenerator`` tells CMake Tools what CMake genertors to prefer.
   The first supported generator in this list is used when configuring a project
   for the first time. If a project is already configured, the generator will not

--- a/package.json
+++ b/package.json
@@ -219,6 +219,11 @@
                     "default": true,
                     "description": "Save open files before building"
                 },
+                "cmake.buildBeforeRun": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Build the target before running it."
+                },
                 "cmake.clearOutputBeforeBuild": {
                     "type": "boolean",
                     "default": true,

--- a/src/common.ts
+++ b/src/common.ts
@@ -872,6 +872,9 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
           `The current debug target "${this.currentLaunchTarget}" no longer exists. Select a new target to debug.`);
           return null;
     }
+    const build_before = config.buildBeforeRun;
+    if (!build_before) return target;
+
     const build_retc = await this.build(target.name);
     if (build_retc !== 0) return null;
     return target;

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,10 @@ export class ConfigurationReader {
     return this._readPrefixed<string>('sourceDirectory') as string;
   }
 
+  get buildBeforeRun(): boolean {
+    return !!this._readPrefixed<boolean>('buildBeforeRun');
+  }
+
   get saveBeforeBuild(): boolean {
     return !!this._readPrefixed<boolean>('saveBeforeBuild');
   }


### PR DESCRIPTION
Adds options for #188 

Adds `cmake.buildBeforeRun` default `true` to allow running without building.