### PR TITLE
Add configureBeforeBuild option

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,6 +219,11 @@
                     "default": true,
                     "description": "Save open files before building"
                 },
+                "cmake.configureBeforeBuild": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Always configure the project before building."
+                },
                 "cmake.clearOutputBeforeBuild": {
                     "type": "boolean",
                     "default": true,

--- a/src/common.ts
+++ b/src/common.ts
@@ -995,7 +995,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
     if (!ok) {
       return -1;
     }
-    if (this.needsReconfigure) {
+    if (this.needsReconfigure && config.configureBeforeBuild) {
       const retc = await this.configure([], false);
       if (!!retc) return retc;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,10 @@ export class ConfigurationReader {
     return this._readPrefixed<string>('sourceDirectory') as string;
   }
 
+  get configureBeforeBuild(): boolean {
+    return !!this._readPrefixed<boolean>('configureBeforeBuild');
+  }
+
   get saveBeforeBuild(): boolean {
     return !!this._readPrefixed<boolean>('saveBeforeBuild');
   }


### PR DESCRIPTION
Adds another option that I find handy. `configureBeforeBuild` default true.  Doing a configure each time normally rebuilds targets that haven't always changed at least with the project I work on.   Turning off `configureBeforeBuild` normally gives faster builds.