### PR TITLE
handle vscode special vars in cmake.*environment options

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -533,7 +533,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
    * @brief Read the source directory from the config
    */
   get sourceDir(): string {
-    const dir = util.replaceVars(config.sourceDirectory);
+    const dir = this.replaceVars(config.sourceDirectory);
     return util.normalizePath(dir);
   }
 
@@ -549,7 +549,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
    * @brief Get the path to the binary dir
    */
   public get binaryDir(): string {
-    const dir = util.replaceVars(config.buildDirectory);
+    const dir = this.replaceVars(config.buildDirectory);
     return util.normalizePath(dir, false);
   }
 
@@ -954,7 +954,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
     await util.writeFile(init_cache_path, init_cache_content);
     let prefix = config.installPrefix;
     if (prefix && prefix !== '') {
-      prefix = util.replaceVars(prefix);
+      prefix = this.replaceVars(prefix);
       args.push('-DCMAKE_INSTALL_PREFIX=' + prefix);
     }
 
@@ -1091,7 +1091,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
       }
       else if (typeof(value) === 'string') {
         typestr = 'STRING';
-        value = util.replaceVars(value)
+        value = this.replaceVars(value)
         value = util.replaceAll(value, ';', '\\;');
       }
       else if (value instanceof Number || typeof value === 'number') {

--- a/src/common.ts
+++ b/src/common.ts
@@ -513,24 +513,11 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
     return cached ? cached : null;
   }
 
-  public replaceVars(str: string): string {
-    const replacements = [
-      ['${buildType}', this.selectedBuildType || 'Unknown'],
-      ['${workspaceRoot}', vscode.workspace.rootPath],
-      [
-        '${workspaceRootFolderName}', path.basename(vscode.workspace.rootPath || '.')
-      ],
-      ['${toolset}', config.toolset]
-    ] as [string, string][];
-    return replacements.reduce(
-        (accdir, [needle, what]) => util.replaceAll(accdir, needle, what), str);
-  }
-
   /**
    * @brief Read the source directory from the config
    */
   get sourceDir(): string {
-    const dir = this.replaceVars(config.sourceDirectory);
+    const dir = util.replaceVars(config.sourceDirectory);
     return util.normalizePath(dir);
   }
 
@@ -546,7 +533,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
    * @brief Get the path to the binary dir
    */
   public get binaryDir(): string {
-    const dir = this.replaceVars(config.buildDirectory);
+    const dir = util.replaceVars(config.buildDirectory);
     return util.normalizePath(dir, false);
   }
 
@@ -951,7 +938,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
     await util.writeFile(init_cache_path, init_cache_content);
     let prefix = config.installPrefix;
     if (prefix && prefix !== '') {
-      prefix = this.replaceVars(prefix);
+      prefix = util.replaceVars(prefix);
       args.push('-DCMAKE_INSTALL_PREFIX=' + prefix);
     }
 
@@ -1088,7 +1075,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
       }
       else if (typeof(value) === 'string') {
         typestr = 'STRING';
-        value = this.replaceVars(value)
+        value = util.replaceVars(value)
         value = util.replaceAll(value, ';', '\\;');
       }
       else if (value instanceof Number || typeof value === 'number') {

--- a/src/common.ts
+++ b/src/common.ts
@@ -514,6 +514,22 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
   }
 
   /**
+   * @brief Replace all predefined variable by their actual values in the
+   * input string.
+   *
+   * This method takes care of variables that depend on CMake configuration,
+   * such as the built type, etc. All variables that do not need to know
+   * of CMake should go to util.replaceVars instead.
+   */
+  public replaceVars(str: string): string {
+    const replacements = [
+      ['${buildType}', this.selectedBuildType || 'Unknown']
+    ] as [string, string][];
+    return util.replaceVars(replacements.reduce(
+        (accdir, [needle, what]) => util.replaceAll(accdir, needle, what), str));
+  }
+
+  /**
    * @brief Read the source directory from the config
    */
   get sourceDir(): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as util from './util';
 
 import {Maybe} from './util';
 
@@ -9,6 +10,15 @@ export class ConfigurationReader {
     const config = vscode.workspace.getConfiguration('cmake');
     const value = config.get(key);
     return (value !== undefined) ? value as T : default_;
+  }
+
+  private _escapePaths(obj: Object) {
+    return Object.getOwnPropertyNames(obj).reduce(
+      (acc, key: string) => {
+        acc[key] = util.replaceVars(obj[key]);
+        return acc;
+      },
+      {});
   }
 
   private _readPrefixed<T>(key): T|null {
@@ -114,19 +124,19 @@ export class ConfigurationReader {
   }
 
   get environment() {
-    return this._readPrefixed<{[key: string]: string}>('environment') || {};
+    return this._escapePaths(this._readPrefixed<{[key: string]: string}>('environment') || {});
   }
 
   get configureEnvironment() {
-    return this._readPrefixed<{[key: string]: string}>('configureEnvironment') || {};
+    return this._escapePaths(this._readPrefixed<{[key: string]: string}>('configureEnvironment') || {});
   }
 
   get buildEnvironment() {
-    return this._readPrefixed<{[key: string]: string}>('buildEnvironment') || {};
+    return this._escapePaths(this._readPrefixed<{[key: string]: string}>('buildEnvironment') || {});
   }
 
   get testEnvironment() {
-    return this._readPrefixed<{[key: string]: string}>('testEnvironment') || {};
+    return this._escapePaths(this._readPrefixed<{[key: string]: string}>('testEnvironment') || {});
   }
 
   get defaultVariants(): Object {

--- a/src/util.ts
+++ b/src/util.ts
@@ -552,5 +552,5 @@ export function replaceVars(str: string): string {
     ['${toolset}', config.toolset]
   ] as [string, string][];
   return replacements.reduce(
-      (accdir, [needle, what]) => util.replaceAll(accdir, needle, what), str);
+      (accdir, [needle, what]) => replaceAll(accdir, needle, what), str);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -541,3 +541,16 @@ export function parseCompileDefinition(str: string): [string, string | null] {
 export function pause(time: number): Promise<void> {
     return new Promise<void>(resolve => setTimeout(resolve, time));
 }
+
+export function replaceVars(str: string): string {
+  const replacements = [
+    ['${buildType}', this.selectedBuildType || 'Unknown'],
+    ['${workspaceRoot}', vscode.workspace.rootPath],
+    [
+      '${workspaceRootFolderName}', path.basename(vscode.workspace.rootPath || '.')
+    ],
+    ['${toolset}', config.toolset]
+  ] as [string, string][];
+  return replacements.reduce(
+      (accdir, [needle, what]) => util.replaceAll(accdir, needle, what), str);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -542,9 +542,14 @@ export function pause(time: number): Promise<void> {
     return new Promise<void>(resolve => setTimeout(resolve, time));
 }
 
+/**
+ * @brief Replace all predefined variable by their actual values in the
+ * input string.
+ *
+ * This method handles all variables that do not need to know of CMake.
+ */
 export function replaceVars(str: string): string {
   const replacements = [
-    ['${buildType}', this.selectedBuildType || 'Unknown'],
     ['${workspaceRoot}', vscode.workspace.rootPath],
     [
       '${workspaceRootFolderName}', path.basename(vscode.workspace.rootPath || '.')


### PR DESCRIPTION
Related to issue #193 
I had the time to take a closer look at the source code, and I noticed that a function was already existing : common.replaceVars. So I put that in util.ts, and in config.ts I created a private function to apply this to all the values in environment objects.

Unfortunately, I couldn't test anything because I don't know how to setup VSCode to compile this extension and then install / test it ... so I hope you can take a look and tell me how to proceed from here :) I'm willing to rework the pull request (if I don't follow the coding style, if I did something not recommended, etc.) so don't hesitate to tell me if there's something wrong !