### PR TITLE
Add support for detecting Emscripten environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -558,7 +558,16 @@
                     "default": [
                         "C:\\MinGW"
                     ],
-                    "description": "Directors where MinGW may be installed"
+                    "description": "Directories where MinGW may be installed"
+                },
+                "cmake.emscriptenSearchDirs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "Path to a directory"
+                    },
+                    "default": [],
+                    "description": "Directories where Emscripten may be installed"
                 },
                 "cmake.useCMakeServer": {
                     "type": "boolean",

--- a/src/common.ts
+++ b/src/common.ts
@@ -221,6 +221,9 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
   public get currentEnvironmentVariables() {
     return this._environments.currentEnvironmentVariables;
   }
+  public get currentEnvironmentSettings() {
+    return this._environments.currentEnvironmentSettings;
+  }
 
   public getPreferredGenerators(): Generator[] {
     const configGenerators = config.preferredGenerators.map(g => <Generator>{ name: g });
@@ -991,6 +994,8 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
     const args = [] as string[];
 
     const settings = Object.assign({}, config.configureSettings);
+    Object.assign(settings, this.currentEnvironmentSettings || {});
+
     if (!this.isMultiConf) {
       settings.CMAKE_BUILD_TYPE = this.selectedBuildType;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,6 +174,10 @@ export class ConfigurationReader {
   public get mingwSearchDirs(): string[] {
     return this._readPrefixed<string[]>('mingwSearchDirs') || [];
   }
+
+  public get emscriptenSearchDirs(): string[] {
+    return this._readPrefixed<string[]>('emscriptenSearchDirs') || [];
+  }
 }
 
 export const config = new ConfigurationReader();

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -21,6 +21,7 @@ export interface Environment {
   description?: string;
   mutex?: string;
   variables: Map<string, string>;
+  settings?: Object;
   preferredGenerator?: Generator;
 }
 
@@ -235,6 +236,35 @@ async function tryCreateMinGWEnvironment(dir: string): Promise<Environment | und
   return;
 }
 
+// Detect Emscripten environment
+async function tryCreateEmscriptenEnvironment(emscripten: string): Promise<Environment | undefined> {
+  let cmake_toolchain = path.join(emscripten, 'cmake', 'Modules', 'Platform', 'Emscripten.cmake');
+  if (await async.exists(cmake_toolchain)) {
+    // read version and strip "" and newlines
+    let version = fs.readFileSync(path.join(emscripten, 'emscripten-version.txt'), 'utf8');
+    version = version.replace(/["\r\n]/g, '');
+    log.verbose('Found Emscripten ' + version + ': ' + cmake_toolchain);
+    if (process.platform === 'win32') {
+      cmake_toolchain = cmake_toolchain.replace(/\\/g, path.posix.sep);
+    }
+    const ret: Environment = {
+      name: `Emscripten - ${version}`,
+      mutex: 'emscripten',
+      description: `Root at ${emscripten}`,
+      settings: {
+        'CMAKE_TOOLCHAIN_FILE': cmake_toolchain
+      },
+      variables: new Map<string, string>([]),
+      preferredGenerator: {
+        name: 'Ninja'
+      }
+    };
+    return ret;
+  }
+
+  return;
+}
+
 const ENVIRONMENTS: EnvironmentProvider[] = [
   {
     async getEnvironments(): Promise<Environment[]> {
@@ -293,7 +323,17 @@ const ENVIRONMENTS: EnvironmentProvider[] = [
       const envs = await Promise.all(config.mingwSearchDirs.map(tryCreateMinGWEnvironment));
       return <Environment[]>envs.filter((e) => !!e);
     }
-  }
+  },
+  {
+    async getEnvironments(): Promise<Environment[]> {
+      var dirs = config.emscriptenSearchDirs;
+      var env_dir = process.env['EMSCRIPTEN'];
+      if (env_dir && dirs.indexOf(env_dir) == -1)
+        dirs = dirs.concat(env_dir);
+      const envs = await Promise.all(dirs.map(tryCreateEmscriptenEnvironment));
+      return <Environment[]>envs.filter((e) => !!e);
+    }
+  },
 ];
 
 export async function availableEnvironments(): Promise<Environment[]> {
@@ -397,6 +437,19 @@ export class EnvironmentManager {
     }, {});
     const proc_env = process.env;
     return util.mergeEnvironment(process.env, active_env);
+  }
+  /**
+   * @brief The current cmake settings to use when configuring,
+   *    as specified by the active build environments.
+   */
+  public get currentEnvironmentSettings(): Object {
+    const active_settings = this.activeEnvironments.reduce((acc, name) => {
+      const env_ = this.availableEnvironments.get(name);
+      console.assert(env_);
+      const env = env_!;
+      return env.settings || {};
+    }, {});
+    return active_settings;
   }
 
   public get preferredEnvironmentGenerators(): Generator[] {


### PR DESCRIPTION
[Emscripten](https://github.com/kripken/emscripten) ships with a CMake toolchain file, and it's handy to be able to switch to it as an Environment using vscode-cmake-tools.  This adds an environment detector for Emscripten, using both the `$EMSCRIPTEN` env var as well as a list of configured dirs.

I had to add the ability to merge in settings in addition to env vars from environments for this in order to set `CMAKE_TOOLCHAIN_FILE`; seems to work, but I'm not sure if there's a more canonical way of doing this.