### PR TITLE
allow loading cmake-variants from .vscode folder

### DIFF
--- a/src/variants.ts
+++ b/src/variants.ts
@@ -83,12 +83,17 @@ export const DEFAULT_VARIANTS = {
 
 export class VariantManager implements vscode.Disposable {
   constructor(private readonly _context: vscode.ExtensionContext) {
-    const variants_watcher = vscode.workspace.createFileSystemWatcher(
-        path.join(vscode.workspace.rootPath!, 'cmake-variants.*'));
-    this._disposables.push(variants_watcher);
-    variants_watcher.onDidChange(this._reloadVariants.bind(this));
-    variants_watcher.onDidCreate(this._reloadVariants.bind(this));
-    variants_watcher.onDidDelete(this._reloadVariants.bind(this));
+    const workdir = vscode.workspace.rootPath!;
+    const variants_watchers = [
+      vscode.workspace.createFileSystemWatcher(path.join(workdir, 'cmake-variants.*')),
+      vscode.workspace.createFileSystemWatcher(path.join(workdir, '.vscode', 'cmake-variants.*'))
+    ];
+    for (const variants_watcher of variants_watchers) {
+      this._disposables.push(variants_watcher);
+      variants_watcher.onDidChange(this._reloadVariants.bind(this));
+      variants_watcher.onDidCreate(this._reloadVariants.bind(this));
+      variants_watcher.onDidDelete(this._reloadVariants.bind(this));
+    }
     this._reloadVariants();
   }
 

--- a/src/variants.ts
+++ b/src/variants.ts
@@ -194,7 +194,7 @@ export class VariantManager implements vscode.Disposable {
       }
     } else {
       // iterate on the json files
-      for (let json_file of json_files) {
+      for (const json_file of json_files) {
         if (await async.exists(json_file)) {
           const content = (await async.readFile(json_file)).toString();
           try {


### PR DESCRIPTION
As the title says :) This is the request following issue #200

The way it works is pretty simple: it tries to look for the `cmake-variants.json` file in the usual location (workspace root) and if it doesn't find it here, it tries to look in the `.vscode` folder.

If needed, I could update the documentation so that the loading priority is explicitly defined somewhere for users (and unrelated, but GitHub, VSCode and most Markdown viewers handle relative links in Markdown files so in the doc you can use them :))