### PR TITLE
Fixed incorrect VS 2015 detection

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -305,7 +305,7 @@ const ENVIRONMENTS: EnvironmentProvider[] = [
         log.verbose('VSWhere is not installed. Not searching for VS 2017');
         return [];
       }
-      const vswhere_res = await async.execute(vswhere, ['-all', '-format', 'json', '-products', '*']);
+      const vswhere_res = await async.execute(vswhere, ['-all', '-format', 'json', '-products', '*', '-legacy']);
       const installs: VSWhereItem[] = JSON.parse(vswhere_res.stdout);
       const archs = ['x86', 'amd64', 'arm'];
       const all_promices = installs


### PR DESCRIPTION
The default algorithm for detecting VS 2015 installations searches for a missing "vcvarsall.bat" in the "VS140COMNTOOLS" path.
So for detecting older versions of VS we also can use the new detection routine by using "vswhere" with the "-legacy" option.