### PR TITLE
Fix for #216

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -71,6 +71,19 @@ export class ServerClientCMakeTools extends common.CommonCMakeToolsBase {
     return null;
   }
 
+  get linkerId() {
+    const entry = this.cacheEntry(`CMAKE_LINKER`);
+    if (entry) {
+      const linker = entry.as<string>();
+      if (linker.endsWith('link.exe')) {
+        return 'MSVC';
+      } else if (linker.endsWith('ld')) {
+        return 'GNU';
+      }
+    }
+    return null;
+  }
+
   get needsReconfigure() {
     return this._dirty;
   }

--- a/src/common.ts
+++ b/src/common.ts
@@ -161,6 +161,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
   abstract get executableTargets(): api.ExecutableTarget[];
   abstract get targets(): api.Target[];
   abstract get compilerId(): string|null;
+  abstract get linkerId(): string|null;
   abstract markDirty(): void;
   abstract configure(extraArgs?: string[], runPrebuild?: boolean):
       Promise<number>;
@@ -973,10 +974,11 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
   public async debugTarget(): Promise<void> {
     const target = await this._prelaunchTarget();
     if (!target) return;
+    const msvc = this.compilerId ? this.compilerId.includes('MSVC') :
+      (this.linkerId ? this.linkerId.includes('MSVC') : false);
     const real_config = {
       name: `Debugging Target ${target.name}`,
-      type: (this.compilerId && this.compilerId.includes('MSVC')) ? 'cppvsdbg' :
-                                                                    'cppdbg',
+      type: msvc ? 'cppvsdbg' : 'cppdbg',
       request: 'launch',
       cwd: '${workspaceRoot}',
       args: [],

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -73,6 +73,11 @@ export class CMakeTools extends CommonCMakeToolsBase implements CMakeToolsBacken
         return this._compilerId;
     }
 
+    private _linkerId: Maybe<string> = null;
+    get linkerId() {
+        return this._linkerId;
+    }
+
     private _targets: api.NamedTarget[] = [];
     get targets() { return this._targets; }
 


### PR DESCRIPTION
`CMAKE_CXX_COMPILER` is not always written in the CMake cache file (I don't know why, but check #216 , it seems to happen quite a lot) so I added a `linkerId` property (only in server mode, I don't know how to implement this for the legacy version) which is more reliable (it seems to always be specified)

This way the debug target command will correctly set the debugger type even when `CMAKE_CXX_COMPILER` is not in the cache.