### PR TITLE
Fix #256 - Parsing MSVC diagnostics

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -274,7 +274,7 @@ export class MSVCDiagnosticParser extends DiagnosticParser {
 
   public parseLine(line: string): LineParseResult {
     const msvc_re =
-        /^\s*(?!\d+>)\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+((?:fatal )?error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/;
+        /^\s*(?:\d+>)?\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+((?:fatal )?error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/;
     const res = msvc_re.exec(line);
     if (!res) return PARSER_FAIL;
     const full = res[0];


### PR DESCRIPTION
Change the parsing of the build process number from a negative look-ahead to a non-capturing group, if present.