### PR TITLE
support for ${env:...} syntax

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,16 @@ export class ConfigurationReader {
         `${platform}.${key}`, this.readConfig<T>(`${key}`));
   }
 
+  private _escapeArray(obj:Array<string>){
+    const acc: Array<string> = [];
+    return obj.reduce(
+      (acc,key:string) =>{
+        acc.push(util.replaceVars(key));
+        return acc;
+    },acc)
+
+  }
+
   get buildDirectory(): string {
     return this._readPrefixed<string>('buildDirectory')!;
   }
@@ -78,15 +88,15 @@ export class ConfigurationReader {
   }
 
   get configureArgs(): string[] {
-    return this._readPrefixed<string[]>('configureArgs')!;
+    return this._escapeArray(this._readPrefixed<string[]>('configureArgs') || []);
   }
 
   get buildArgs(): string[] {
-    return this._readPrefixed<string[]>('buildArgs')!;
+    return this._escapeArray(this._readPrefixed<string[]>('buildArgs') || [] );
   }
 
   get buildToolArgs(): string[] {
-    return this._readPrefixed<string[]>('buildToolArgs')!;
+    return this._escapeArray(this._readPrefixed<string[]>('buildToolArgs') || [] );
   }
 
   get parallelJobs(): Maybe<number> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -501,6 +501,16 @@ export function replaceVars(str: string): string {
     ],
     ['${toolset}', config.toolset]
   ] as [string, string][];
-  return replacements.reduce(
+  var retval =  replacements.reduce(
       (accdir, [needle, what]) => replaceAll(accdir, needle, what), str);
+
+  // process ${env:ENVIRONMENT_VAR}
+  let regexp = /\$\{(env:|env.)?(.*?)\}/g;
+  retval = retval.replace(regexp, (match, ignored, name) => {
+    let newValue = process.env[name];
+    return (newValue != null) ? newValue : match;
+  });
+
+
+  return retval;
 }


### PR DESCRIPTION
This adds support for issue #265. It adds a regex match for ${env:...} and a replace with the value from the process environment. That's automatically picked up by many of the properties already but also an escapeArray() method has been added to allow the arrays of config/build/install parameters to pass through substitution as well. 