### PR TITLE
Feature/refactor 1.0 Default choice for variant

### DIFF
--- a/src/variant.ts
+++ b/src/variant.ts
@@ -251,8 +251,7 @@ export class VariantManager implements vscode.Disposable {
     const items: VariantCombination[]
         = product.map(optionset => ({
                         label : optionset.map(o => o.settings.short).join(' + '),
-                        keywordSettings : new Map<string, string>(optionset.map(
-                            param => [param.settingKey, param.settingValue] as[string, string])),
+                        keywordSettings : this.getVariantSettingsForVariantCombination(optionset),
                         description : optionset.map(o => o.settings.long).join(' + '),
                       }));
     const chosen = await vscode.window.showQuickPick(items);
@@ -262,6 +261,16 @@ export class VariantManager implements vscode.Disposable {
     this.stateManager.activeVariantSettings = chosen.keywordSettings;
     this._activeVariantChanged.fire();
     return true;
+  }
+
+  getVariantSettingsForVariantCombination( variantCombination : Array<any>) : Map<string, string> {
+    const variantSetting = new Map<string, string>();
+
+    Array.from(variantCombination).map((variantItem : any) => {
+      variantSetting.set(variantItem['settingKey'], variantItem['settingValue']);
+    });
+
+    return variantSetting;
   }
 
   async initialize() { await this._reloadVariantsFile(); }


### PR DESCRIPTION
## Handling of default variant choice

### This changes visible behavior of initial load of a project 

The following changes are proposed:

- small refactoring for reuse of code for variant selection for initial load
- check of default variant choice on parsing of variant configuration file
- load of default choice on start

## The purpose of this change

This modification implements the initial load of default selection of the variant choices.
On start of the extension for a unknown project with cmake_variant.json or yaml are the default selection not loaded. This modification loads the variant configuration defined default choices.
If there is a invalid default choice set then the modification will give a warning and replace the value by the first found choice.
