### PR TITLE
Issue 282

### DIFF
--- a/schemas/kits-schema.json
+++ b/schemas/kits-schema.json
@@ -109,7 +109,7 @@
                     },
                     {
                         "properties": {
-                            "visualStudioVersion": {
+                            "visualStudio": {
                                 "type": "string",
                                 "description": "Name of the Visual Studio product"
                             },
@@ -137,7 +137,7 @@
                         },
                         "required": [
                             "name",
-                            "visualStudioVersion",
+                            "visualStudio",
                             "visualStudioArchitecture"
                         ]
                     }

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -50,7 +50,6 @@ const build_log = logging.createLogger('build');
 export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   private _http_server: http.Server;
   private _ws_server: ws.Server;
-  private _editor_provider: vscode.Disposable;
 
   private _nagManager = new NagManager(this.extensionContext);
 
@@ -101,7 +100,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         };
       });
 
-      this._editor_provider = vscode.workspace.registerTextDocumentContentProvider(
+      vscode.workspace.registerTextDocumentContentProvider(
           'cmake-cache',
           new CacheEditorContentProvider(this.extensionContext, editor_server.address().port));
     });

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -218,7 +218,8 @@ export class CMakeServerClientDriver extends CMakeDriver {
 
   private async _restartClient(): Promise<void> {
     this._cmsClient = this._doRestartClient();
-    await this._cmsClient;
+    const client = await this._cmsClient;
+    this._globalSettings = await client.getGlobalSettings();
   }
 
   private async _doRestartClient(): Promise<cms.CMakeServerClient> {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -391,10 +391,11 @@ async function varsForVSInstallation(inst: VSInstallation, arch: string):
  */
 async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?: ProgressReporter):
     Promise<VSKit | null> {
-      const name = inst.displayName + ' - ' + arch;
+      const installName = inst.displayName || inst.instanceId;
+      const name = installName + ' - ' + arch;
       log.debug('Checking for kit: ' + name);
       if (pr) {
-        pr.report({message : `Checking ${inst.displayName} with ${arch}`});
+        pr.report({message : `Checking ${installName} with ${arch}`});
       }
       const variables = await varsForVSInstallation(inst, arch);
       if (!variables)
@@ -403,7 +404,7 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
       const kit: VSKit = {
         type : 'vsKit',
         name : name,
-        visualStudio : inst.displayName,
+        visualStudio : installName,
         visualStudioArchitecture : arch,
       };
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -405,7 +405,7 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
       const kit: VSKit = {
         type : 'vsKit',
         name : name,
-        visualStudio : installName,
+        visualStudio : inst.instanceId,
         visualStudioArchitecture : arch,
       };
 
@@ -444,7 +444,7 @@ export async function scanForVSKits(pr?: ProgressReporter):
 export async function getVSKitEnvironment(kit: VSKit):
     Promise<Map<string, string>| null> {
       const installs = await vsInstallations();
-      const requested = installs.find(inst => inst.displayName == kit.visualStudio);
+      const requested = installs.find(inst => inst.instanceId == kit.visualStudio);
       if (!requested) {
         return null;
       }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -367,6 +367,7 @@ const VsArchitectures: {[key: string] : string}
  * Preferred CMake VS generators by VS version
  */
 const VsGenerators: {[key: string] : string} = {
+  '14' : 'Visual Studio 14 2015',
   '15' : 'Visual Studio 15 2017',
   'VS120COMNTOOLS' : 'Visual Studio 12 2013',
   'VS140COMNTOOLS' : 'Visual Studio 14 2015',


### PR DESCRIPTION
## This change addresses item #282

### This changes [[visible behavior/performance/documentation/etc.]]

The following changes are proposed:

- Add missing identifier for VS 14 2015
- Add use of instanceId if there is no display name

## The purpose of this change
Try to fix #282.

But this is only the first step.
Now I have the problem that the stored json file is invalid.

```
C:\Program Files\Microsoft VS Code\Code.exe --debugBrkPluginHost=8308 --debugId=bb6e2ac1-6e38-446c-8e52-e65b7b117f46 --extensionDevelopmentPath=c:\Users\kristina\Downloads\vscode-cmake-tools 
[CMakeTools] 2017-12-22T17:09:04.918Z [debug] [main] Safe constructing new CMakeTools instance
[CMakeTools] 2017-12-22T17:09:15.807Z [debug] [kit] Constructing KitManager
[CMakeTools] 2017-12-22T17:09:15.807Z [debug] [variant] Constructing VariantManager
[CMakeTools] 2017-12-22T17:09:15.811Z [debug] [main] Constructing new CMakeTools instance
[CMakeTools] 2017-12-22T17:09:15.815Z [debug] [main] Starting CMakeTools second-phase init
[CMakeTools] 2017-12-22T17:09:15.815Z [debug] [rollbar] Checking Rollbar permissions
[CMakeTools] 2017-12-22T17:09:15.819Z [warning] [rollbar] Running CMakeTools in developer mode. Rollbar reporting is disabled.
[CMakeTools] 2017-12-22T17:09:15.891Z [info] [variant] Loaded new set of variants
[CMakeTools] 2017-12-22T17:09:15.895Z [debug] [kit] Second phase init for KitManager
[CMakeTools] 2017-12-22T17:09:15.899Z [debug] [kit] Re-read kits file from prior session
[CMakeTools] 2017-12-22T17:09:15.899Z [debug] [kit] Re-reading kits file C:\Users\kristina\AppData\Roaming\CMakeTools\cmake-kits.json
[CMakeTools] 2017-12-22T17:09:15.927Z [error] [kit] Invalid cmake-kits.json:
[CMakeTools] 2017-12-22T17:09:15.927Z [error] [kit]  >> [1]: should have required property 'compilers'
[CMakeTools] 2017-12-22T17:09:15.927Z [error] [kit]  >> [1]: should have required property 'toolchainFile'
[CMakeTools] 2017-12-22T17:09:15.931Z [error] [kit]  >> [1]: should have required property 'visualStudioVersion'
[CMakeTools] 2017-12-22T17:09:15.931Z [error] [kit]  >> [1]: should match exactly one schema in oneOf
[CMakeTools] 2017-12-22T17:09:15.931Z [error] [kit]  >> [2]: should have required property 'compilers'
[CMakeTools] 2017-12-22T17:09:15.931Z [error] [kit]  >> [2]: should have required property 'toolchainFile'
[CMakeTools] 2017-12-22T17:09:15.931Z [error] [kit]  >> [2]: should have required property 'visualStudioVersion'
[CMakeTools] 2017-12-22T17:09:15.931Z [error] [kit]  >> [2]: should match exactly one schema in oneOf
[CMakeTools] 2017-12-22T17:09:15.935Z [error] [kit]  >> [3]: should have required property 'compilers'
[CMakeTools] 2017-12-22T17:09:15.935Z [error] [kit]  >> [3]: should have required property 'toolchainFile'
[CMakeTools] 2017-12-22T17:09:15.935Z [error] [kit]  >> [3]: should have required property 'visualStudioVersion'
[CMakeTools] 2017-12-22T17:09:15.935Z [error] [kit]  >> [3]: should match exactly one schema in oneOf
[CMakeTools] 2017-12-22T17:09:15.939Z [error] [kit]  >> [4]: should have required property 'compilers'
[CMakeTools] 2017-12-22T17:09:15.939Z [error] [kit]  >> [4]: should have required property 'toolchainFile'
[CMakeTools] 2017-12-22T17:09:15.939Z [error] [kit]  >> [4]: should have required property 'visualStudioVersion'
[CMakeTools] 2017-12-22T17:09:15.939Z [error] [kit]  >> [4]: should match exactly one schema in oneOf
[CMakeTools] 2017-12-22T17:09:15.939Z [error] [kit]  >> [5]: should have required property 'compilers'
[CMakeTools] 2017-12-22T17:09:15.943Z [error] [kit]  >> [5]: should have required property 'toolchainFile'
[CMakeTools] 2017-12-22T17:09:15.943Z [error] [kit]  >> [5]: should have required property 'visualStudioVersion'
[CMakeTools] 2017-12-22T17:09:15.943Z [error] [kit]  >> [5]: should match exactly one schema in oneOf
[CMakeTools] 2017-12-22T17:09:15.943Z [error] [kit]  >> [6]: should have required property 'compilers'
[CMakeTools] 2017-12-22T17:09:15.943Z [error] [kit]  >> [6]: should have required property 'toolchainFile'
[CMakeTools] 2017-12-22T17:09:15.943Z [error] [kit]  >> [6]: should have required property 'visualStudioVersion'
[CMakeTools] 2017-12-22T17:09:15.943Z [error] [kit]  >> [6]: should match exactly one schema in oneOf
[CMakeTools] 2017-12-22T17:09:15.947Z [info] [kit] Successfully loaded 0 kits
[CMakeTools] 2017-12-22T17:09:15.947Z [debug] [kit] Active kit set to null
[CMakeTools] 2017-12-22T17:09:15.951Z [debug] [main] Starting CMake driver
[CMakeTools] 2017-12-22T17:09:16.162Z [debug] [cms-client] Started new CMake Server instance with PID 13696
rejected promise not handled within 1 second
Received message from cmake-server: 
{"supportedProtocolVersions":[{"isExperimental":true,"major":1,"minor":1}],"type":"hello"}

[CMakeTools] 2017-12-22T17:09:17.176Z [debug] [driver] Trying to detect generator supported by system
[CMakeTools] 2017-12-22T17:09:17.184Z [error] [cms-client] None of preferred generators available on the system.
Activating extension `vector-of-bool.cmake-tools` failed: Unable to determine CMake Generator to use.
Activating extension `vector-of-bool.cmake-tools` failed:  Unable to determine CMake Generator to use
Here is the error stack:  Error: Unable to determine CMake Generator to use
	at onHello (c:\Users\kristina\Downloads\vscode-cmake-tools\out\src\cms-client.js:262:39)
	at <anonymous>
	at process._tickCallback (internal/process/next_tick.js:109:7)
[CMakeTools] 2017-12-22T17:09:17.196Z [fatal] [rollbar] Unhandled exception: Unhandled Promise rejection: quickStart Error: Unable to determine CMake Generator to use {}
Error: Unable to determine CMake Generator to use
	at onHello (c:\Users\kristina\Downloads\vscode-cmake-tools\out\src\cms-client.js:262:39)
	at <anonymous>
	at process._tickCallback (internal/process/next_tick.js:109:7)
```

## Other Notes/Information
I made a pull request so that you can see my activites. May be you can reuse them and fix the problem or I will look in the next days for it.
