### PR TITLE
Stabile extension on exceptions 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,7 +42,8 @@
             ],
             "env": {
                 "CMT_TESTING": "1",
-                "CMT_QUIET_CONSOLE": "1"
+                "CMT_QUIET_CONSOLE": "1",
+                "HasVs": "true"
             },
             "preLaunchTask": "npm"
             // "smartStep": true

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -123,7 +123,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   private readonly _variantManager = new VariantManager(this._stateManager);
 
   /**
-   * The object in charge of talking to CMake. It starts out as invalid because
+   * The object in charge of talking to CMake. It starts empty (null) because
    * we don't know what driver to use at the current time. The driver also has
    * two-phase init and a private constructor. The driver may be replaced at
    * any time by the user making changes to the workspace configuration.
@@ -304,6 +304,14 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     this._nagManager.start();
   }
 
+  /**
+   * Returns, if possible a cmake driver instance. To creation the driver instance,
+   * there are preconditions that should be fulfilled, such as an active kit is selected.
+   * These preconditions are checked before it driver instance creation. When creating a
+   * driver instance, this function waits until the driver is ready before returning.
+   * This ensures that user commands can always be executed, because error criterials like
+   * exceptions would assign a null driver and it is possible to create a new driver instance later again.
+   */
   async getCMakeDriverInstance() : Promise<CMakeDriver | null> {
     if (!this._kitManager.hasActiveKit) {
       return null;

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -128,7 +128,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    * two-phase init and a private constructor. The driver may be replaced at
    * any time by the user making changes to the workspace configuration.
    */
-  private _cmakeDriver: CMakeDriver | null = null;
+  private _cmakeDriver: Promise<CMakeDriver> | null = null;
 
   /**
    * The status bar manager. Has two-phase init.
@@ -310,11 +310,10 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
 
     if (!this._cmakeDriver) {
-      let d = this._startNewCMakeDriver();
-      this._cmakeDriver = await(d);
+      this._cmakeDriver = this._startNewCMakeDriver();
       // Reload any test results. This will also update visibility on the status
       // bar
-      await this._ctestController.reloadTests(this._cmakeDriver);
+      await this._ctestController.reloadTests(await this._cmakeDriver);
       this._statusBar.targetName = this.defaultBuildTarget || await this.allTargetName;
     }
     return this._cmakeDriver;

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -448,7 +448,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     if (drv) {
       return drv.allTargetName;
     } else {
-      return "";
+      return '';
     }
   }
 
@@ -530,7 +530,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   async showTargetSelector(): Promise<string | null> {
     const drv = await this.getCMakeDriverInstance();
     if (!drv) {
-      return "";
+      return '';
     }
 
     if (!drv.targets.length) {
@@ -844,7 +844,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
     return drv.then(d => {
       if (!d) {
-        return "";
+        return '';
       }
       return d.sourceDir
     });
@@ -855,7 +855,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
     return drv.then(d => {
       if (!d) {
-        return "";
+        return '';
       }
       return d.mainListFile
     });
@@ -866,7 +866,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
     return drv.then(d => {
       if (!d) {
-        return "";
+        return '';
       }
       return d.binaryDir
     });
@@ -877,7 +877,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
     return drv.then(d => {
       if (!d) {
-        return "";
+        return '';
       }
       return d.cachePath
     });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -98,18 +98,6 @@ suite('Kits test', async () => {
     expect(kits.length).to.eq(0);
   });
 
-  test('KitManager tests', async() => {
-    const cmt = await getExtension();
-    const sm = new state.StateManager(cmt.extensionContext);
-    const km = new kit.KitManager(sm);
-    await km.initialize();
-    const editor = await km.openKitsEditor();
-    // Ensure it is the active editor
-    await vscode.window.showTextDocument(editor.document);
-    // Now close it. We don't care about it any more
-    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
-  });
-
   suite('Scan directory', async () => {
     let path_with_compilername = "";
     setup(async () => { path_with_compilername = path.join(fakebin, "gcc-4.3.2"); });
@@ -178,7 +166,7 @@ suite('Kits test', async () => {
 
       const newKitFileExists = await fs.exists(path_rescan_kit);
       expect(newKitFileExists).to.be.true;
-    }).timeout(5000);
+    }).timeout(10000);
 
     test('check valid kit file for test system compilers', async () => {
       await km.initialize();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -36,7 +36,7 @@ function clearExistingKitConfigurationFile() {
 async function getExtension() {
   const cmt = vscode.extensions.getExtension<CMakeTools>('vector-of-bool.cmake-tools');
   if (!cmt) {
-    return Promise.reject("Extension doesn't exist");
+    throw new Error("Extension doesn't exist");
   }
   return cmt.isActive ? Promise.resolve(cmt.exports) : cmt.activate();
 }
@@ -94,12 +94,12 @@ suite('Kits test', async () => {
   });
 
   test('Scan non exisiting dir for kits', async() => {
-    const kits = await kit.scanDirForCompilerKits("");
+    const kits = await kit.scanDirForCompilerKits('');
     expect(kits.length).to.eq(0);
   });
 
   suite('Scan directory', async () => {
-    let path_with_compilername = "";
+    let path_with_compilername = '';
     setup(async () => { path_with_compilername = path.join(fakebin, "gcc-4.3.2"); });
     teardown(async () => {
       if (await fs.exists(path_with_compilername)) {
@@ -114,7 +114,7 @@ suite('Kits test', async () => {
     });
 
     test('Scan file with compiler name', async () => {
-      await fs.writeFile(path_with_compilername, "")
+      await fs.writeFile(path_with_compilername, '')
       // Scan the directory with fake compilers in it
       const kits = await kit.scanDirForCompilerKits(fakebin);
       expect(kits.length).to.eq(2);
@@ -186,7 +186,7 @@ suite('Kits test', async () => {
 
     // Fails because PATH is tried to split but a empty path is not splitable
     test.skip('check empty kit file', async () => {
-      process.env['PATH'] = "";
+      process.env['PATH'] = '';
 
       await km.initialize();
 
@@ -258,7 +258,7 @@ suite('Kits test', async () => {
 
   test('KitManager tests event on change of active kit', async () => {
     let stateMock = sinon.createStubInstance(state.StateManager);
-    let storedActivatedKitName: string = "";
+    let storedActivatedKitName: string = '';
     sinon.stub(stateMock, 'activeKitName')
         .get(function() { return null; })
         .set(function(kit) { storedActivatedKitName = kit; });
@@ -783,14 +783,14 @@ suite('Compilation info', () => {
 
 suite('CMake System tests', () => {
   (process.env.HasVs == 'true' ? suite.skip : suite)('No present kit',() => {
-        let path_backup = "";
+        let path_backup = '';
         suiteSetup(()=>{
           clearExistingKitConfigurationFile();
 
           // Test will use path to scan for compilers
           // with no path content there is no compiler found
           path_backup = process.env.PATH!;
-          process.env.PATH = "";
+          process.env.PATH = '';
         });
         suiteTeardown(() => {
           // restores old path

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -182,7 +182,7 @@ suite('Kits test', async () => {
       let kitFile = await readValidKitFile(path_rescan_kit);
       let nonVSKits = kitFile.filter((item) => {return item.visualStudio == null});
       expect(nonVSKits.length).to.be.eq(0);
-    }).timeout(5000);
+    }).timeout(10000);
 
     // Fails because PATH is tried to split but a empty path is not splitable
     test.skip('check empty kit file', async () => {
@@ -202,7 +202,7 @@ suite('Kits test', async () => {
       let kitFile = await readValidKitFile(path_rescan_kit);
       let nonVSKits = kitFile.filter((item) => {return item.visualStudio == null});
       expect(nonVSKits.length).to.be.eq(2);
-    }).timeout(5000);
+    }).timeout(10000);
 
     test('check check combination of scan and old kits', async () => {
       process.env['PATH'] = testFilePath("fakebin");
@@ -222,7 +222,7 @@ suite('Kits test', async () => {
       expect(names).to.contains("VSCode Kit 2");
       expect(names).to.contains("Clang 0.25");
       expect(names).to.contains("GCC 42.1");
-    }).timeout(5000);
+    }).timeout(10000);
   });
 
   suite('GUI test', async () => {
@@ -253,7 +253,7 @@ suite('Kits test', async () => {
         expect(editor.document.getText()).to.be.eq(rawKitsFromFile);
       } else {
       }
-    }).timeout(5000);
+    }).timeout(10000);
   });
 
   test('KitManager tests event on change of active kit', async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -782,6 +782,9 @@ suite('Compilation info', () => {
 });
 
 suite('CMake System tests', () => {
+  // This test will be skip when a Visual Studio installation marker (Env.HasVs=true) is present.
+  // At the moment it is not possible to hide an installation against the test. In that case
+  // it is not possible to test a no present kit, because VS will provid always kits.
   (process.env.HasVs == 'true' ? suite.skip : suite)('No present kit',() => {
         let path_backup = '';
         suiteSetup(()=>{

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -18,6 +18,7 @@ import * as ajv from 'ajv';
 
 import * as api from '../src/api';
 import * as compdb from '../src/compdb';
+import {CMakeTools} from '../src/cmake-tools';
 import {CMakeCache} from '../src/cache';
 import * as diags from '../src/diagnostics';
 import * as kit from '../src/kit';
@@ -26,6 +27,7 @@ import {OutputConsumer} from '../src/proc';
 import * as state from '../src/state';
 import * as util from '../src/util';
 
+const here = __dirname;
 
 function clearExistingKitConfigurationFile() {
   fs.writeFile( path.join(dirs.dataDir, 'cmake-kits.json'), "[]");
@@ -106,6 +108,7 @@ suite('Kits test', async () => {
     await vscode.window.showTextDocument(editor.document);
     // Now close it. We don't care about it any more
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  });
 
   suite('Scan directory', async () => {
     let path_with_compilername = "";
@@ -719,9 +722,7 @@ suite('Diagnostics', async () => {
   });
 });
 
-import * as compdb from '../src/compdb';
 import dirs from '../src/dirs';
-import { fs } from '../src/pr';
 
 suite('Compilation info', () => {
   test('Parsing compilation databases', async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -794,10 +794,19 @@ suite('Compilation info', () => {
 
 suite('CMake System tests', () => {
   (process.env.HasVs == 'true' ? suite.skip : suite)('No present kit',() => {
+        let path_backup = "";
         suiteSetup(()=>{
           clearExistingKitConfigurationFile();
+
+          // Test will use path to scan for compilers
+          // with no path content there is no compiler found
+          path_backup = process.env.PATH!;
           process.env.PATH = "";
         });
+        suiteTeardown(() => {
+          // restores old path
+          process.env.PATH = path_backup;
+        })
 
         test('Scan for no existing kit should return no selected kit', async() => {
           const cmt = await getExtension();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -694,6 +694,9 @@ suite('Diagnostics', async () => {
   });
 });
 
+import * as compdb from '../src/compdb';
+
+
 suite('Compilation info', () => {
   test('Parsing compilation databases', async () => {
     const dbpath = testFilePath('test_compdb.json');
@@ -761,4 +764,14 @@ suite('Compilation info', () => {
     expect(info.compileFlags[0]).to.eq('/Z+:some-compile-flag');
     expect(info.compiler).to.eq('cl.exe');
   });
+
+  suite('CMake System tests', () => {
+    test('Test no present kit', async() => {
+      const cmt = await getExtension();
+      process.env.PATH = "";
+      await cmt.scanForKits();
+      expect(cmt.selectKit()).to.null;
+    });
+  });
+
 });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -793,30 +793,30 @@ suite('Compilation info', () => {
 });
 
 suite('CMake System tests', () => {
-  suite('No present kit',() => {
-    suiteSetup(()=>{
-      clearExistingKitConfigurationFile();
-      process.env.PATH = "";
+  (process.env.HasVs == 'true' ? suite.skip : suite)('No present kit',() => {
+        suiteSetup(()=>{
+          clearExistingKitConfigurationFile();
+          process.env.PATH = "";
+        });
+
+        test('Scan for no existing kit should return no selected kit', async() => {
+          const cmt = await getExtension();
+          await cmt.scanForKits();
+          expect(await cmt.selectKit()).to.be.eq(null);
+        });
+
+        test('Configure ', async() => {
+          const cmt = await getExtension();
+          await cmt.scanForKits();
+
+          expect(await cmt.configure()).to.be.eq(-1);
+        });
+
+        test('Build', async() => {
+          const cmt = await getExtension();
+          await cmt.scanForKits();
+
+          expect(await cmt.build()).to.be.eq(-1);
+        });
     });
-
-    test('Scan for no existing kit should return no selected kit', async() => {
-      const cmt = await getExtension();
-      await cmt.scanForKits();
-      expect(await cmt.selectKit()).to.be.eq(null);
-    });
-
-    test('Configure ', async() => {
-      const cmt = await getExtension();
-      await cmt.scanForKits();
-
-      expect(await cmt.configure()).to.be.eq(-1);
-    });
-
-    test('Build', async() => {
-      const cmt = await getExtension();
-      await cmt.scanForKits();
-
-      expect(await cmt.build()).to.be.eq(-1);
-    });
-  });
 });


### PR DESCRIPTION
Move load of cmake server to later state.

### This changes stability

The following changes are proposed:

- Move initialization to need
- Replace access to _cmakedriver by get instance function with error handling

## The purpose of this change

The initialization of the cmake server on construction of the extension, does not allow to edit kits or reset the state of extension on a cmake problem. This modification delays the cmake server initialization. 
