### PR TITLE
Support MSVC 2008

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1121,7 +1121,7 @@ export abstract class CommonCMakeToolsBase implements CMakeToolsBackend {
         return [];
       else if (/(Unix|MinGW) Makefiles|Ninja/.test(gen) && target !== 'clean')
         return ['-j', config.numJobs.toString()];
-      else if (/Visual Studio/.test(gen))
+      else if (/Visual Studio(?! 9 2008)/.test(gen)) // negative lookahead to exclude MSVC 2008 which does not support these flags
         return ['/m', '/property:GenerateFullPaths=true'];
       else
         return [];


### PR DESCRIPTION
### This changes

The following changes are proposed:

- Do not add build flags for MSVC 2008, because 2008 doesn't support these
   - '/m', '/property:GenerateFullPaths=true'

## The purpose of this change

Without this it's not possible to build within VS Code using MSVC 2008 compiler.

## Other Notes/Information

I noticed that the new beta has an TODO for this, so I beg for have it done in the final release ;-).
