### PR TITLE
[Beta4] Support custom environments and configureArgs

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -513,7 +513,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
     const settings_flags
         = util.objectPairs(settings).map(([ key, value ]) => _makeFlag(key, util.cmakeify(value as string)));
-    const flags = [ '--no-warn-unused-cli' ].concat(extra_args);
+    const flags = [ '--no-warn-unused-cli' ].concat(extra_args, config.configureArgs);
 
     console.assert(!!this._kit);
     if (!this._kit) {

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -222,6 +222,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const cur_env = process.env as proc.EnvironmentVariables;
     const env = util.mergeEnvironment(cur_env,
                                       this.getKitEnvironmentVariablesObject(),
+                                      config.environment,
                                       (options && options.environment) ? options.environment : {});
     const exec_options = Object.assign({}, options, {environment : env});
     return proc.execute(command, args, consumer, exec_options);
@@ -440,7 +441,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const candidates = this.getPreferredGenerators();
     for (const gen of candidates) {
       const gen_name = gen.name;
-      const generator_present = await (async(): Promise<boolean> => {
+      const generator_present = await(async(): Promise<boolean> => {
         if (gen_name == 'Ninja') {
           return await this.testHaveCommand('ninja-build') || await this.testHaveCommand('ninja');
         }
@@ -644,7 +645,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const args = [ '--build', this.binaryDir, '--config', this.currentBuildType, '--target', target, '--' ].concat(
         generator_args);
     const cmake = await paths.cmakePath;
-    const child = this.executeCommand(cmake, args, consumer);
+    const child = this.executeCommand(cmake, args, consumer, {environment : config.buildEnvironment});
     this._currentProcess = child;
     await child.result;
     this._currentProcess = null;

--- a/test/test_environment.bat
+++ b/test/test_environment.bat
@@ -1,0 +1,4 @@
+@echo off
+
+REM Print out the testing environment variables
+echo "TEST_ENV: %TEST_ENV% | TEST_BUILD_ENV: %TEST_BUILD_ENV% | TEST_CONFIG_ENV: %TEST_CONFIG_ENV%"

--- a/test/test_environment.sh
+++ b/test/test_environment.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Print out the testing environment variables
+echo "TEST_ENV: $TEST_ENV | TEST_BUILD_ENV: $TEST_BUILD_ENV | TEST_CONFIG_ENV: $TEST_CONFIG_ENV"

--- a/test/test_environment.sh
+++ b/test/test_environment.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Print out the testing environment variables
-echo "TEST_ENV: $TEST_ENV | TEST_BUILD_ENV: $TEST_BUILD_ENV | TEST_CONFIG_ENV: $TEST_CONFIG_ENV"
+echo '"TEST_ENV: $TEST_ENV | TEST_BUILD_ENV: $TEST_BUILD_ENV | TEST_CONFIG_ENV: $TEST_CONFIG_ENV"'

--- a/test/test_environment.sh
+++ b/test/test_environment.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Print out the testing environment variables
-echo '"TEST_ENV: $TEST_ENV | TEST_BUILD_ENV: $TEST_BUILD_ENV | TEST_CONFIG_ENV: $TEST_CONFIG_ENV"'
+echo "\"TEST_ENV: $TEST_ENV | TEST_BUILD_ENV: $TEST_BUILD_ENV | TEST_CONFIG_ENV: $TEST_CONFIG_ENV\""


### PR DESCRIPTION
## This change addresses item #305 

### Changes
This PR addresses the missing support for the following setting fields:
- `cmake.environment`
- `cmake.buildEnvironment`
- `cmake.configureArgs`

__*Update 1:*__
I have added tests for the following cases:
- Passing 'fake' `config.environment` to `proc.execute`
- Passing 'fake' merged `config.environment` and `config.buildEnvironment` to `proc.execute`
- Passing 'fake' merged `config.environment` and `config.configureEnvironment` to `proc.execute`

I am referring to the passed env vars as fake, because I couldn't get the test to read out the `settings.json`, so I just created fake string arrays. If anyone knows how to read out the `settings.json` from within the tests, please post how 😄.

## Other Notes/Information
This PR doesn't add support for `cmake.configureEnvironment`. I will do that in my other PR for variable expansion/substitution (#317).

Closes #305.