### PR TITLE
[Beta4] Add setting field `cmake.autoRestartBuild`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,8 @@ class ConfigurationReader {
 
   get clearOutputBeforeBuild(): boolean { return !!readPrefixedConfig<boolean>('clearOutputBeforeBuild'); }
 
+  get autoRestartBuild(): boolean { return !!readPrefixedConfig<boolean>('autoRestartBuild'); }
+
   get configureSettings(): any { return readPrefixedConfig<Object>('configureSettings'); }
 
   get initialBuildType(): string|null { return readPrefixedConfig<string>('initialBuildType'); }

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -574,6 +574,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     if (this._isBusy) {
       if (config.autoRestartBuild) {
         log.debug('Stopping current CMake task.');
+        vscode.window.showInformationMessage('Stopping current CMake task and starting new build.');
         this.stopCurrentProcess();
       } else {
         log.debug('No configuring: We\'re busy.');
@@ -651,7 +652,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const cmake = await paths.cmakePath;
     const child = this.executeCommand(cmake, args, consumer);
     this._currentProcess = child;
+    this._isBusy = true;
     await child.result;
+    this._isBusy = false;
     this._currentProcess = null;
     return child;
   }

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -440,7 +440,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const candidates = this.getPreferredGenerators();
     for (const gen of candidates) {
       const gen_name = gen.name;
-      const generator_present = await (async(): Promise<boolean> => {
+      const generator_present = await(async(): Promise<boolean> => {
         if (gen_name == 'Ninja') {
           return await this.testHaveCommand('ninja-build') || await this.testHaveCommand('ninja');
         }
@@ -572,9 +572,14 @@ export abstract class CMakeDriver implements vscode.Disposable {
   private async _beforeConfigure(): Promise<boolean> {
     log.debug('Runnnig pre-configure checks and steps');
     if (this._isBusy) {
-      log.debug('No configuring: We\'re busy.');
-      vscode.window.showErrorMessage('A CMake task is already running. Stop it before trying to configure.');
-      return false;
+      if (config.autoRestartBuild) {
+        log.debug('Stopping current CMake task.');
+        this.stopCurrentProcess();
+      } else {
+        log.debug('No configuring: We\'re busy.');
+        vscode.window.showErrorMessage('A CMake task is already running. Stop it before trying to configure.');
+        return false;
+      }
     }
 
     if (!this.sourceDir) {
@@ -585,7 +590,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
     const cmake_list = this.mainListFile;
     if (!await fs.exists(cmake_list)) {
-      log.debug('No configuring: There is no', cmake_list);
+      log.debug('No configuring: There is no ', cmake_list);
       const do_quickstart
           = await vscode.window.showErrorMessage('You do not have a CMakeLists.txt', 'Quickstart a new CMake project');
       if (do_quickstart)


### PR DESCRIPTION
## This change addresses item #318 

### Changes
I have added a setting field named `cmake.autoRestartBuild`.
When this field is turned on, running CMake tasks will get stopped if the user starts a new one.

Closes #318.