### PR TITLE
[Beta4] Add support for buildArgs and buildToolArgs

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -440,7 +440,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const candidates = this.getPreferredGenerators();
     for (const gen of candidates) {
       const gen_name = gen.name;
-      const generator_present = await (async(): Promise<boolean> => {
+      const generator_present = await(async(): Promise<boolean> => {
         if (gen_name == 'Ninja') {
           return await this.testHaveCommand('ninja-build') || await this.testHaveCommand('ninja');
         }
@@ -641,8 +641,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
       else
         return [];
     })();
-    const args = [ '--build', this.binaryDir, '--config', this.currentBuildType, '--target', target, '--' ].concat(
-        generator_args);
+    const args = [ '--build', this.binaryDir, '--config', this.currentBuildType, '--target', target, '--' ]
+                     .concat(config.buildArgs, generator_args, config.buildToolArgs);
     const cmake = await paths.cmakePath;
     const child = this.executeCommand(cmake, args, consumer);
     this._currentProcess = child;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -643,11 +643,11 @@ export abstract class CMakeDriver implements vscode.Disposable {
         return [];
     })();
 
-    const args = [ '--build', this.binaryDir, '--config', this.currentBuildType, '--target', target, '--' ]
-                     .concat(generator_args, config.buildToolArgs, config.buildArgs);
+    const args = [ '--build', this.binaryDir, '--config', this.currentBuildType, '--target', target ]
+                     .concat(config.buildArgs, [ '--' ], generator_args, config.buildToolArgs);
     const expanded_args_promises = args.map(async (value: string) => await this.expandString(value));
     const expanded_args = await Promise.all(expanded_args_promises);
-    log.trace('CMake build args are', JSON.stringify(expanded_args));
+    log.trace('CMake build args are: ', JSON.stringify(expanded_args));
 
     const cmake = await paths.cmakePath;
     const child = this.executeCommand(cmake, expanded_args, consumer);


### PR DESCRIPTION
## This change addresses item #232 

### Changes
I have added support for `cmake.buildArgs` and `cmake.buildToolArgs`.
Variable substitution should also work.

Closes #232.