### PR TITLE
More TSLint and clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -61,9 +61,11 @@ SpacesInAngles:  false
 SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
 SpaceAfterCStyleCast: false
-SpacesInContainerLiterals: true
+SpacesInContainerLiterals: false
 SpaceBeforeAssignmentOperators: true
 ContinuationIndentWidth: 4
 SpaceBeforeParens: ControlStatements
+JavaScriptWrapImports: true
+JavaScriptQuotes: Single
 DisableFormat:   false
 ...

--- a/package.json
+++ b/package.json
@@ -652,6 +652,7 @@
     "compile": "./node_modules/.bin/tsc -watch -p ./",
     "compile-once": "./node_modules/.bin/tsc -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
+    "lint": "node ./node_modules/tslint/bin/tslint -p . --fix",
     "docs": "node ./node_modules/.bin/typedoc --mode modules --excludeExternals --out build/docs/dev --readme none src/"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -672,6 +672,7 @@
     "chai-as-promised": "^7.1.1",
     "mocha": "~3.4.2",
     "sinon": "^4.1.4",
+    "tslint": "^5.9.1",
     "typedoc": "^0.8.0",
     "typescript": "~2.3.0",
     "vscode": "~1.1.5"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 pushd .
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -11,6 +13,9 @@ fi
 
 cd $ROOT
 
+# Run tslint
+node ./node_modules/tslint/bin/tslint -p $ROOT
+
 export HasVs=false
 export CMT_TESTING=1
 
@@ -19,11 +24,5 @@ export CMT_TESTING=1
 export CODE_TESTS_PATH=$ROOT/out/test/unit_tests
 export CODE_TESTS_WORKSPACE=$ROOT/test/unit_tests/test_project_without_cmakelists
 node ./node_modules/vscode/bin/test
-test_error_code=$?
 
 popd
-
-# Forward error level
-if [ $test_error_code -ne 0 ]; then
-	exit $test_error_code
-fi

--- a/src/api.ts
+++ b/src/api.ts
@@ -75,7 +75,7 @@ export interface RawCompilationInfo {
 export interface CompilationInfo {
   file: string;
   compile?: RawCompilationInfo;
-  includeDirectories: {path: string; isSystem : boolean;}[];
+  includeDirectories: {path: string; isSystem: boolean;}[];
   compileDefinitions: {[define: string]: string|null};
   compileFlags: string[];
   compiler?: string;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -16,11 +16,11 @@ const log = logging.createLogger('cache');
  * information. This type is immutable.
  */
 export class Entry implements api.CacheEntry {
-  private _type: api.CacheEntryType = api.CacheEntryType.Uninitialized;
-  private _docs: string = '';
-  private _key: string = '';
-  private _value: any = null;
-  private _advanced: boolean = false;
+  private readonly _type: api.CacheEntryType = api.CacheEntryType.Uninitialized;
+  private readonly _docs: string = '';
+  private readonly _key: string = '';
+  private readonly _value: any = null;
+  private readonly _advanced: boolean = false;
 
   get type() { return this._type; }
 
@@ -157,8 +157,8 @@ export class CMakeCache {
             INTERNAL : api.CacheEntryType.Internal,
             UNINITIALIZED : api.CacheEntryType.Uninitialized,
             STATIC : api.CacheEntryType.Static,
-          } as {[type: string] : api.CacheEntryType};
-          const type: api.CacheEntryType = typemap[typename];
+          } as {[type: string] : api.CacheEntryType | undefined};
+          const type = typemap[typename];
           const docs = docs_acc.trim();
           docs_acc = '';
           if (type === undefined) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -54,7 +54,7 @@ export class Entry implements api.CacheEntry {
     this._docs = docs;
     this._advanced = advanced;
   }
-};
+}
 
 /**
  * Reads a CMake cache file. This class is immutable.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -76,7 +76,7 @@ export class CMakeCache {
       log.trace('File exists');
       const content = await fs.readFile(path);
       log.trace('File contents read successfully');
-      const entries = await CMakeCache.parseCache(content.toString());
+      const entries = CMakeCache.parseCache(content.toString());
       log.trace('Parsed', entries.size, 'entries from', path);
       return new CMakeCache(path, exists, entries);
     } else {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -150,14 +150,14 @@ export class CMakeCache {
         } else {
           const key = name;
           const typemap = {
-            BOOL : api.CacheEntryType.Bool,
-            STRING : api.CacheEntryType.String,
-            PATH : api.CacheEntryType.Path,
-            FILEPATH : api.CacheEntryType.FilePath,
-            INTERNAL : api.CacheEntryType.Internal,
-            UNINITIALIZED : api.CacheEntryType.Uninitialized,
-            STATIC : api.CacheEntryType.Static,
-          } as {[type: string] : api.CacheEntryType | undefined};
+            BOOL: api.CacheEntryType.Bool,
+            STRING: api.CacheEntryType.String,
+            PATH: api.CacheEntryType.Path,
+            FILEPATH: api.CacheEntryType.FilePath,
+            INTERNAL: api.CacheEntryType.Internal,
+            UNINITIALIZED: api.CacheEntryType.Uninitialized,
+            STATIC: api.CacheEntryType.Static,
+          } as {[type: string]: api.CacheEntryType | undefined};
           const type = typemap[typename];
           const docs = docs_acc.trim();
           docs_acc = '';
@@ -182,7 +182,7 @@ export class CMakeCache {
    */
   get(key: string): Entry|null {
     const ret = this._entries.get(key) || null;
-    log.trace(`Get cache key ${key}=${ret ? ret.value : "[[Misisng]]"}`);
+    log.trace(`Get cache key ${key}=${ret ? ret.value : '[[Misisng]]'}`);
     return ret;
   }
 }

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -184,14 +184,14 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         // We purposefully exclude versions <3.7.1, which have some major CMake
         // server bugs
         if (util.versionGreater(version, '3.7.1')) {
-          return await CMakeServerClientDriver.create(this._stateManager, kit);
+          return CMakeServerClientDriver.create(this._stateManager, kit);
         } else {
           log.info(
               'CMake Server is not available with the current CMake executable. Please upgrade to CMake 3.7.2 or newer.');
         }
       }
       // We didn't start the server backend, so we'll use the legacy one
-      return await LegacyCMakeDriver.create(this._stateManager, kit);
+      return LegacyCMakeDriver.create(this._stateManager, kit);
     })();
     await drv.setVariantOptions(this._variantManager.activeVariantOptions);
     const project = drv.projectName;

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -7,10 +7,10 @@ import * as vscode from 'vscode';
 import * as ws from 'ws';
 
 import * as api from './api';
-import {ExecutionOptions, ExecutionResult} from "./api";
-import {CacheEditorContentProvider} from "./cache-editor";
+import {ExecutionOptions, ExecutionResult} from './api';
+import {CacheEditorContentProvider} from './cache-editor';
 import {CMakeServerClientDriver} from './cms-driver';
-import config from "./config";
+import config from './config';
 import {CTestDriver} from './ctest';
 import * as diags from './diagnostics';
 import {populateCollection} from './diagnostics';
@@ -18,7 +18,7 @@ import {CMakeDriver} from './driver';
 import {KitManager} from './kit';
 import {LegacyCMakeDriver} from './legacy-driver';
 import * as logging from './logging';
-import {NagManager} from "./nag";
+import {NagManager} from './nag';
 import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
@@ -73,9 +73,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     });
 
     rollbar.takePromise('Setup cache editor server', {}, ready.then(() => {
-      const websock_server = this._ws_server = ws.createServer({server : editor_server});
+      const websock_server = this._ws_server = ws.createServer({server: editor_server});
       websock_server.on('connection', client => {
-        const sub = this.onReconfigured(() => { client.send(JSON.stringify({method : 'refreshContent'})); });
+        const sub = this.onReconfigured(() => { client.send(JSON.stringify({method: 'refreshContent'})); });
         client.onclose = () => { sub.dispose(); };
         client.onmessage = msg => {
           const data = JSON.parse(msg.data);
@@ -84,14 +84,14 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
             return this._handleCacheEditorMessage(data.method, data.params)
                 .then(ret => {
                   client.send(JSON.stringify({
-                    id : data.id,
-                    result : ret,
+                    id: data.id,
+                    result: ret,
                   }));
                 })
                 .catch(e => {
                   client.send(JSON.stringify({
-                    id : data.id,
-                    error : (e as Error).message,
+                    id: data.id,
+                    error: (e as Error).message,
                   }));
                 });
           });
@@ -172,7 +172,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     const drv = await (async () => {
       log.debug('Starting CMake driver');
       const cmake = await paths.cmakePath;
-      const version_ex = await proc.execute(cmake, [ '--version' ]).result;
+      const version_ex = await proc.execute(cmake, ['--version']).result;
       if (version_ex.retc !== 0 || !version_ex.stdout) {
         throw new Error(`Bad CMake executable "${cmake}". Is it installed and a valid executable?`);
       }
@@ -221,7 +221,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     if (drv) {
       return drv.executeCommand(cmake, args, undefined, options).result;
     } else {
-      throw new Error("Unable to execute cmake command, there is no valid cmake driver instance.");
+      throw new Error('Unable to execute cmake command, there is no valid cmake driver instance.');
     }
   }
 
@@ -230,7 +230,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     if (drv) {
       return drv.executeCommand(program, args, undefined, options).result;
     } else {
-      throw new Error("Unable to execute program, there is no valid cmake driver instance.");
+      throw new Error('Unable to execute program, there is no valid cmake driver instance.');
     }
   }
 
@@ -239,7 +239,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     if (drv) {
       return drv.compilationInfoForFile(filepath);
     } else {
-      throw new Error("Unable to get compilation information, there is no valid cmake driver instance.");
+      throw new Error('Unable to get compilation information, there is no valid cmake driver instance.');
     }
   }
 
@@ -329,7 +329,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         await this._ctestController.reloadTests(cmakeInstance!);
         this._statusBar.targetName = this.defaultBuildTarget || await this.allTargetName;
       } catch (ex) {
-        log.debug("Exception on start of cmake driver.", ex.stack);
+        log.debug('Exception on start of cmake driver.', ex.stack);
         this._cmakeDriver = Promise.resolve(null);
       }
     }
@@ -546,18 +546,18 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
 
     if (!drv.targets.length) {
-      return (await vscode.window.showInputBox({prompt : 'Enter a target name'})) || null;
+      return (await vscode.window.showInputBox({prompt: 'Enter a target name'})) || null;
     } else {
       const choices = drv.targets.map((t): vscode.QuickPickItem => {
         switch (t.type) {
         case 'named': {
           return {
-            label : t.name,
-            description : 'Target to build',
+            label: t.name,
+            description: 'Target to build',
           };
         }
         case 'rich': {
-          return {label : t.name, description : t.targetType, detail : t.filepath};
+          return {label: t.name, description: t.targetType, detail: t.filepath};
         }
         }
       });
@@ -662,9 +662,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
 
     const choices = executableTargets.map(e => ({
-                                            label : e.name,
-                                            description : '',
-                                            detail : e.path,
+                                            label: e.name,
+                                            description: '',
+                                            detail: e.path,
                                           }));
     const chosen = await vscode.window.showQuickPick(choices);
     if (!chosen) {
@@ -729,19 +729,19 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         = drv.compilerID ? drv.compilerID.includes('MSVC') : (drv.linkerID ? drv.linkerID.includes('MSVC') : false);
     const mi_mode = process.platform == 'darwin' ? 'lldb' : 'gdb';
     const debug_config: vscode.DebugConfiguration = {
-      type : is_msvc ? 'cppvsdbg' : 'cppdbg',
-      name : `Debug ${target_path}`,
-      request : 'launch',
-      cwd : '${workspaceRoot}',
-      args : [],
-      MIMode : mi_mode,
+      type: is_msvc ? 'cppvsdbg' : 'cppdbg',
+      name: `Debug ${target_path}`,
+      request: 'launch',
+      cwd: '${workspaceRoot}',
+      args: [],
+      MIMode: mi_mode,
     };
     if (mi_mode == 'gdb') {
       debug_config['setupCommands'] = [
         {
-          description : 'Enable pretty-printing for gdb',
-          text : '-enable-pretty-printing',
-          ignoreFailures : true,
+          description: 'Enable pretty-printing for gdb',
+          text: '-enable-pretty-printing',
+          ignoreFailures: true,
         },
       ];
     }
@@ -765,7 +765,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       return null;
     }
     if (!this._launchTerminal)
-      this._launchTerminal = vscode.window.createTerminal("CMake/Launch");
+      this._launchTerminal = vscode.window.createTerminal('CMake/Launch');
     this._launchTerminal.sendText(target_path);
     this._launchTerminal.show();
     return this._launchTerminal;
@@ -787,8 +787,8 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
 
     const project_name = await vscode.window.showInputBox({
-      prompt : 'Enter a name for the new project',
-      validateInput : (value: string) : string => {
+      prompt: 'Enter a name for the new project',
+      validateInput: (value: string): string => {
         if (!value.length)
           return 'A project name is required';
         return '';
@@ -799,10 +799,10 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
     const target_type = (await vscode.window.showQuickPick([
       {
-        label : 'Library',
-        description : 'Create a library',
+        label: 'Library',
+        description: 'Create a library',
       },
-      {label : 'Executable', description : 'Create an executable'}
+      {label: 'Executable', description: 'Create an executable'}
     ]));
 
     if (!target_type)

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -47,10 +47,10 @@ const build_log = logging.createLogger('build');
  * class. See the `_init` private method for this initialization.
  */
 export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
-  private _http_server: http.Server;
+  private readonly _http_server: http.Server;
   private _ws_server: ws.Server;
 
-  private _nagManager = new NagManager(this.extensionContext);
+  private readonly _nagManager = new NagManager(this.extensionContext);
 
   /**
    * Construct a new instance. The instance isn't ready, and must be initalized.
@@ -74,10 +74,10 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
     rollbar.takePromise('Setup cache editor server', {}, ready.then(() => {
       const websock_server = this._ws_server = ws.createServer({server : editor_server});
-      websock_server.on('connection', (client) => {
+      websock_server.on('connection', client => {
         const sub = this.onReconfigured(() => { client.send(JSON.stringify({method : 'refreshContent'})); });
         client.onclose = () => { sub.dispose(); };
-        client.onmessage = (msg) => {
+        client.onmessage = msg => {
           const data = JSON.parse(msg.data);
           console.log('Got message from editor client', msg);
           rollbar.invokeAsync('Handle message from cache editor', () => {
@@ -134,7 +134,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   /**
    * The status bar manager. Has two-phase init.
    */
-  private _statusBar: StatusBar = new StatusBar();
+  private readonly _statusBar: StatusBar = new StatusBar();
 
   /**
    * Dispose the extension
@@ -208,11 +208,11 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    * Event fired after CMake configure runs
    */
   get onReconfigured() { return this._onReconfiguredEmitter.event; }
-  private _onReconfiguredEmitter = new vscode.EventEmitter<void>();
+  private readonly _onReconfiguredEmitter = new vscode.EventEmitter<void>();
 
   get reconfigured() { return this.onReconfigured; }
 
-  private _onTargetChangedEmitter = new vscode.EventEmitter<void>();
+  private readonly _onTargetChangedEmitter = new vscode.EventEmitter<void>();
   get targetChangedEvent() { return this._onTargetChangedEmitter.event; }
 
   async executeCMakeCommand(args: string[], options?: ExecutionOptions): Promise<ExecutionResult> {
@@ -320,10 +320,10 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       return null;
     }
 
-    if ((await this._cmakeDriver) == null) {
+    if ((await this._cmakeDriver) === null) {
       try {
         this._cmakeDriver = this._startNewCMakeDriver();
-        let cmakeInstance = await this._cmakeDriver;
+        const cmakeInstance = await this._cmakeDriver;
         // Reload any test results. This will also update visibility on the status
         // bar
         await this._ctestController.reloadTests(cmakeInstance!);
@@ -380,7 +380,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    * Implementation of `cmake.configure`
    */
   configure(extra_args: string[] = []) {
-    return this._doConfigure(async (consumer) => {
+    return this._doConfigure(async consumer => {
       const drv = await this.getCMakeDriverInstance();
       if (drv) {
         return drv.configure(extra_args, consumer);
@@ -394,7 +394,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    * Implementation of `cmake.cleanConfigure()
    */
   cleanConfigure() {
-    return this._doConfigure(async (consumer) => {
+    return this._doConfigure(async consumer => {
       const drv = await this.getCMakeDriverInstance();
       if (drv) {
         return drv.cleanConfigure(consumer);
@@ -458,7 +458,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    * Check if the current project needs to be (re)configured
    */
   private async _needsReconfigure(): Promise<boolean> {
-    let drv = await this.getCMakeDriverInstance();
+    const drv = await this.getCMakeDriverInstance();
     if (!drv || drv.needsReconfigure) {
       return true;
     } else {
@@ -581,7 +581,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     return this.build();
   }
 
-  private _ctestController = new CTestDriver();
+  private readonly _ctestController = new CTestDriver();
   async ctest(): Promise<number> {
     const build_retc = await this.build();
     if (build_retc !== 0) {

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -282,7 +282,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
           this._statusBar.setBuildTypeLabel(this._variantManager.activeVariantOptions.short);
           // We don't configure yet, since someone else might be in the middle of a configure
         }
-      })
+      });
     });
     // Listen for the kit to change
     this._kitManager.onActiveKitChanged(kit => {
@@ -557,7 +557,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
           };
         }
         case 'rich': {
-          return { label: t.name, description: t.targetType, detail: t.filepath }
+          return {label : t.name, description : t.targetType, detail : t.filepath};
         }
         }
       });
@@ -727,7 +727,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
     const is_msvc
         = drv.compilerID ? drv.compilerID.includes('MSVC') : (drv.linkerID ? drv.linkerID.includes('MSVC') : false);
-    const mi_mode = process.platform == 'darwin' ? 'lldb' : 'gdb'
+    const mi_mode = process.platform == 'darwin' ? 'lldb' : 'gdb';
     const debug_config: vscode.DebugConfiguration = {
       type : is_msvc ? 'cppvsdbg' : 'cppdbg',
       name : `Debug ${target_path}`,
@@ -892,7 +892,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!d) {
         return '';
       }
-      return d.sourceDir
+      return d.sourceDir;
     });
   }
 
@@ -903,7 +903,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!d) {
         return '';
       }
-      return d.mainListFile
+      return d.mainListFile;
     });
   }
 
@@ -914,7 +914,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!d) {
         return '';
       }
-      return d.binaryDir
+      return d.binaryDir;
     });
   }
 
@@ -925,7 +925,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!d) {
         return '';
       }
-      return d.cachePath
+      return d.cachePath;
     });
   }
 
@@ -936,7 +936,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!d) {
         return [];
       }
-      return d.targets
+      return d.targets;
     });
   }
 
@@ -947,7 +947,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!d) {
         return [];
       }
-      return d.executableTargets
+      return d.executableTargets;
     });
   }
 

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -498,8 +498,8 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       } else {
         build_log.info('Build finished with exit code', rc);
       }
-      const diags = consumer.compileConsumer.createDiagnostics(drv.binaryDir);
-      populateCollection(this._buildDiagnostics, diags);
+      const file_diags = consumer.compileConsumer.createDiagnostics(drv.binaryDir);
+      populateCollection(this._buildDiagnostics, file_diags);
       return rc === null ? -1 : rc;
     } finally {
       this._statusBar.setIsBusy(false);

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -333,7 +333,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     const drv = await this._startNewCMakeDriver();
     // Reload any test results. This will also update visibility on the status bar
     await this._ctestController.reloadTests(drv);
-    this._statusBar.targetName = this.defaultBuildTarget || 'all';
+    this._statusBar.targetName = this.defaultBuildTarget || drv.allTargetName;
     return drv;
   }
 

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -72,7 +72,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       });
     });
 
-    ready.then(() => {
+    rollbar.takePromise('Setup cache editor server', {}, ready.then(() => {
       const websock_server = this._ws_server = ws.createServer({server : editor_server});
       websock_server.on('connection', (client) => {
         const sub = this.onReconfigured(() => { client.send(JSON.stringify({method : 'refreshContent'})); });
@@ -102,7 +102,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
           .registerTextDocumentContentProvider('cmake-cache',
                                                new CacheEditorContentProvider(this.extensionContext,
                                                                               editor_server.address().port));
-    });
+    }));
   }
 
   /**
@@ -143,7 +143,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     log.debug('Disposing CMakeTools extension');
     if (this._launchTerminal)
       this._launchTerminal.dispose();
-    rollbar.invoke('Root dispose', () => this.asyncDispose());
+    rollbar.invokeAsync('Root dispose', () => this.asyncDispose());
   }
 
   /**
@@ -459,7 +459,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    */
   private async _needsReconfigure(): Promise<boolean> {
     let drv = await this.getCMakeDriverInstance();
-    if (!drv || await drv.needsReconfigure) {
+    if (!drv || drv.needsReconfigure) {
       return true;
     } else {
       return false;

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -7,7 +7,7 @@ import * as cache from './cache';
 import config from './config';
 import {CMakeGenerator} from './kit';
 import {createLogger} from './logging';
-import {fs} from "./pr";
+import {fs} from './pr';
 import * as proc from './proc';
 import rollbar from './rollbar';
 import * as util from './util';
@@ -133,7 +133,7 @@ export interface HandshakeParams {
   extraGenerator?: string;
   platform?: string;
   toolset?: string;
-  protocolVersion: {major: number; minor : number;};
+  protocolVersion: {major: number; minor: number;};
 }
 
 export interface HandshakeRequest extends CookiedMessage, HandshakeParams {
@@ -158,9 +158,9 @@ export interface GlobalSettingsRequest extends CookiedMessage, GlobalSettingsPar
 export interface GlobalSettingsContent {
   buildDirectory: string;
   capabilities: {
-    generators: {extraGenerators: string[]; name : string; platformSupport : boolean; toolsetSupport : boolean;}[];
-    serverMode : boolean;
-    version : {isDirty : boolean; major : number; minor : number; patch : number; string : string; suffix : string;};
+    generators: {extraGenerators: string[]; name: string; platformSupport: boolean; toolsetSupport: boolean;}[];
+    serverMode: boolean;
+    version: {isDirty: boolean; major: number; minor: number; patch: number; string: string; suffix: string;};
   };
   checkSystemVars: boolean;
   extraGenerator: string;
@@ -302,7 +302,7 @@ export interface CMakeInputsRequest extends CookiedMessage, CMakeInputsParams {
 }
 
 export interface CMakeInputsContent {
-  buildFiles: {isCMake: boolean; isTemporary : boolean; sources : string[];}[];
+  buildFiles: {isCMake: boolean; isTemporary: boolean; sources: string[];}[];
   cmakeRootDirectory: string;
   sourceDirectory: string;
 }
@@ -326,7 +326,7 @@ export interface CacheContent {
 
 export interface CMakeCacheEntry {
   key: string;
-  properties: {ADVANCED: '0'|'1'; HELPSTRING : string};
+  properties: {ADVANCED: '0'|'1'; HELPSTRING: string};
   type: string;
   value: string;
 }
@@ -473,7 +473,7 @@ export class CMakeServerClient {
           await fs.unlink(this._pipeFilePath);
         }
       });
-      rollbar.takePromise('Unlink pipe', {pipe : this._pipeFilePath}, unlink_pr);
+      rollbar.takePromise('Unlink pipe', {pipe: this._pipeFilePath}, unlink_pr);
       this._params.onHello(some as HelloMessage).catch(e => { log.error('Unhandled error in onHello', e); });
       return;
     }
@@ -509,7 +509,7 @@ export class CMakeServerClient {
     const cp = {type, ...params};
     const cookie = cp.cookie = Math.random().toString();
     const pr = new Promise(
-        (resolve, reject) => { this._promisesResolvers.set(cookie, {resolve : resolve, reject : reject}); });
+        (resolve, reject) => { this._promisesResolvers.set(cookie, {resolve: resolve, reject: reject}); });
     const msg = JSON.stringify(cp);
     console.log(`Sending message to cmake-server: ${msg}`);
     this._pipe.write('\n[== "CMake Server" ==[\n');
@@ -550,8 +550,8 @@ export class CMakeServerClient {
     this._pipeFilePath = pipe_file;
     const final_env = util.mergeEnvironment(process.env as proc.EnvironmentVariables, params.environment);
     const child = this._proc
-        = child_proc.spawn(params.cmakePath, [ '-E', 'server', '--experimental', `--pipe=${pipe_file}` ], {
-            env : final_env,
+        = child_proc.spawn(params.cmakePath, ['-E', 'server', '--experimental', `--pipe=${pipe_file}`], {
+            env: final_env,
           });
     log.debug(`Started new CMake Server instance with PID ${child.pid}`);
     child.stdout.on('data', this._onErrorData.bind(this));
@@ -570,11 +570,11 @@ export class CMakeServerClient {
         });
       });
       const exit_promise = new Promise<void>(resolve => { child.on('exit', () => { resolve(); }); });
-      this._endPromise = Promise.all([ end_promise, exit_promise ]).then(() => {});
+      this._endPromise = Promise.all([end_promise, exit_promise]).then(() => {});
       this._proc = child;
       child.on('close', (retc: number, signal: string) => {
         if (retc !== 0) {
-          log.error("The connection to cmake-server was terminated unexpectedly");
+          log.error('The connection to cmake-server was terminated unexpectedly');
           log.error(`cmake-server exited with status ${retc} (${signal})`);
           params.onCrash(retc, signal).catch(e => { log.error(`Unhandled error in onCrash ${e}`); });
         }
@@ -590,24 +590,24 @@ export class CMakeServerClient {
     return new Promise<CMakeServerClient>((resolve, reject) => {
       const client = new CMakeServerClient({
         tmpdir,
-        sourceDir : params.sourceDir,
-        binaryDir : params.binaryDir,
-        onMessage : params.onMessage,
-        cmakePath : params.cmakePath,
-        environment : params.environment,
-        onProgress : params.onProgress,
-        onDirty : params.onDirty,
-        pickGenerator : params.pickGenerator,
-        onCrash : async retc => {
+        sourceDir: params.sourceDir,
+        binaryDir: params.binaryDir,
+        onMessage: params.onMessage,
+        cmakePath: params.cmakePath,
+        environment: params.environment,
+        onProgress: params.onProgress,
+        onDirty: params.onDirty,
+        pickGenerator: params.pickGenerator,
+        onCrash: async retc => {
           if (!resolved) {
             reject(new StartupError(retc));
           }
         },
-        onHello : async (msg: HelloMessage) => {
+        onHello: async (msg: HelloMessage) => {
           // We've gotten the hello message. We need to commense handshake
           try {
             const hsparams: HandshakeParams
-                = {buildDirectory : params.binaryDir, protocolVersion : msg.supportedProtocolVersions[0]};
+                = {buildDirectory: params.binaryDir, protocolVersion: msg.supportedProtocolVersions[0]};
 
             const cache_path = path.join(params.binaryDir, 'CMakeCache.txt');
             const have_cache = await fs.exists(cache_path);

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -508,8 +508,7 @@ export class CMakeServerClient {
   sendRequest(type: string, params: any = {}): Promise<any> {
     const cp = {type, ...params};
     const cookie = cp.cookie = Math.random().toString();
-    const pr = new Promise(
-        (resolve, reject) => { this._promisesResolvers.set(cookie, {resolve, reject}); });
+    const pr = new Promise((resolve, reject) => { this._promisesResolvers.set(cookie, {resolve, reject}); });
     const msg = JSON.stringify(cp);
     console.log(`Sending message to cmake-server: ${msg}`);
     this._pipe.write('\n[== "CMake Server" ==[\n');

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -509,7 +509,7 @@ export class CMakeServerClient {
     const cp = {type, ...params};
     const cookie = cp.cookie = Math.random().toString();
     const pr = new Promise(
-        (resolve, reject) => { this._promisesResolvers.set(cookie, {resolve: resolve, reject: reject}); });
+        (resolve, reject) => { this._promisesResolvers.set(cookie, {resolve, reject}); });
     const msg = JSON.stringify(cp);
     console.log(`Sending message to cmake-server: ${msg}`);
     this._pipe.write('\n[== "CMake Server" ==[\n');

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -317,7 +317,7 @@ export interface CMakeInputsReply extends ReplyMessage, CMakeInputsContent {
 export interface CacheParams {}
 
 export interface CacheRequest extends CookiedMessage, CacheParams {
-  type: 'cache'
+  type: 'cache';
 }
 
 export interface CacheContent {

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -413,14 +413,13 @@ export class CMakeServerClient {
       if (!mat) {
         break;
       }
-      const [_all, content, tail] = mat;
-      if (!_all || !content || !tail) {
+      if (mat.length !== 3) {
         debugger;
         throw new global.Error('Protocol error talking to CMake! Got this input: ' + input);
       }
-      this._accInput = tail;
-      console.log(`Received message from cmake-server: ${content}`);
-      const message: SomeMessage = JSON.parse(content);
+      this._accInput = mat[2];
+      console.log(`Received message from cmake-server: ${mat[1]}`);
+      const message: SomeMessage = JSON.parse(mat[1]);
       this._onMessage(message);
     }
   }

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -4,11 +4,11 @@ import * as vscode from 'vscode';
 import * as api from './api';
 import {CacheEntryProperties, ExecutableTarget, RichTarget} from "./api";
 import * as cache from './cache';
-import paths from './paths';
 import * as cms from './cms-client';
 import {CMakeDriver} from "./driver";
 import {Kit} from "./kit";
 import {createLogger} from './logging';
+import paths from './paths';
 import {fs} from "./pr";
 import * as proc from './proc';
 import rollbar from './rollbar';
@@ -116,7 +116,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
         STATIC : api.CacheEntryType.Static,
       };
       const type = entry_map[el.type];
-      if (type == undefined) {
+      if (type === undefined) {
         rollbar.error(`Unknown cache entry type ${el.type}`);
         return acc;
       }
@@ -212,7 +212,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
           });
           if (found) {
             const defs = (group.defines || []).map(util.parseCompileDefinition);
-            const defs_o = defs.reduce((acc, [ key, value ]) => { return Object.assign(acc, {[key] : value}); }, {});
+            const defs_o = defs.reduce((acc, [ key, value ]) => ({...acc, [key] : value}), {});
             const includes = (group.includePath || []).map(p => ({path : p.path, isSystem : p.isSystem || false}));
             const flags = util.splitCommandLine(group.compileFlags);
             return {
@@ -250,13 +250,13 @@ export class CMakeServerClientDriver extends CMakeDriver {
       cmakePath : await paths.cmakePath,
       environment : this.getKitEnvironmentVariablesObject(),
       onDirty : async () => { this._dirty = true },
-      onMessage : async (msg) => { this._onMessageEmitter.fire(msg.message); },
-      onProgress : async (_prog) => {},
+      onMessage : async msg => { this._onMessageEmitter.fire(msg.message); },
+      onProgress : async _prog => {},
       pickGenerator : () => this.getBestGenerator(),
     });
   }
 
-  private _onMessageEmitter = new vscode.EventEmitter<string>();
+  private readonly _onMessageEmitter = new vscode.EventEmitter<string>();
   get onMessage() { return this._onMessageEmitter.event; }
 
   async doInit(): Promise<void> { await this._restartClient(); }

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -189,7 +189,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
       await fs.rmdir(this.binaryDir);
     }
     await cb();
-    this._restartClient();
+    await this._restartClient();
   }
 
   async compilationInfoForFile(filepath: string): Promise<api.CompilationInfo|null> {

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -249,7 +249,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
       sourceDir : this.sourceDir,
       cmakePath : await paths.cmakePath,
       environment : this.getKitEnvironmentVariablesObject(),
-      onDirty : async () => { this._dirty = true },
+      onDirty : async () => { this._dirty = true; },
       onMessage : async msg => { this._onMessageEmitter.fire(msg.message); },
       onProgress : async _prog => {},
       pickGenerator : () => this.getBestGenerator(),

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -2,17 +2,17 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import * as api from './api';
-import {CacheEntryProperties, ExecutableTarget, RichTarget} from "./api";
+import {CacheEntryProperties, ExecutableTarget, RichTarget} from './api';
 import * as cache from './cache';
 import * as cms from './cms-client';
-import {CMakeDriver} from "./driver";
-import {Kit} from "./kit";
+import {CMakeDriver} from './driver';
+import {Kit} from './kit';
 import {createLogger} from './logging';
 import paths from './paths';
-import {fs} from "./pr";
+import {fs} from './pr';
 import * as proc from './proc';
 import rollbar from './rollbar';
-import {StateManager} from "./state";
+import {StateManager} from './state';
 import * as util from './util';
 
 const log = createLogger('cms-driver');
@@ -72,7 +72,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
     });
 
     try {
-      await cl.configure({cacheArguments : args});
+      await cl.configure({cacheArguments: args});
       await cl.compute();
       this._dirty = false;
     } catch (e) {
@@ -107,13 +107,13 @@ export class CMakeServerClientDriver extends CMakeDriver {
     const clcache = await cl.getCMakeCacheContent();
     this._cacheEntries = clcache.cache.reduce((acc, el) => {
       const entry_map: {[key: string]: api.CacheEntryType|undefined} = {
-        BOOL : api.CacheEntryType.Bool,
-        STRING : api.CacheEntryType.String,
-        PATH : api.CacheEntryType.Path,
-        FILEPATH : api.CacheEntryType.FilePath,
-        INTERNAL : api.CacheEntryType.Internal,
-        UNINITIALIZED : api.CacheEntryType.Uninitialized,
-        STATIC : api.CacheEntryType.Static,
+        BOOL: api.CacheEntryType.Bool,
+        STRING: api.CacheEntryType.String,
+        PATH: api.CacheEntryType.Path,
+        FILEPATH: api.CacheEntryType.FilePath,
+        INTERNAL: api.CacheEntryType.Internal,
+        UNINITIALIZED: api.CacheEntryType.Uninitialized,
+        STATIC: api.CacheEntryType.Static,
       };
       const type = entry_map[el.type];
       if (type === undefined) {
@@ -151,25 +151,25 @@ export class CMakeServerClientDriver extends CMakeDriver {
     }
     return config.projects.reduce<RichTarget[]>((acc, project) => acc.concat(
                                                     project.targets.map(t => ({
-                                                                          type : 'rich' as 'rich',
-                                                                          name : t.name,
-                                                                          filepath : t.artifacts && t.artifacts.length
+                                                                          type: 'rich' as 'rich',
+                                                                          name: t.name,
+                                                                          filepath: t.artifacts && t.artifacts.length
                                                                               ? path.normalize(t.artifacts[0])
                                                                               : 'Utility target',
-                                                                          targetType : t.type,
+                                                                          targetType: t.type,
                                                                         }))),
-                                                [ {
-                                                  type : 'rich' as 'rich',
-                                                  name : this.allTargetName,
-                                                  filepath : 'A special target to build all available targets',
-                                                  targetType : 'META',
-                                                } ]);
+                                                [{
+                                                  type: 'rich' as 'rich',
+                                                  name: this.allTargetName,
+                                                  filepath: 'A special target to build all available targets',
+                                                  targetType: 'META',
+                                                }]);
   }
 
   get executableTargets(): ExecutableTarget[] {
     return this.targets.filter(t => t.targetType === 'EXECUTABLE').map(t => ({
-                                                                         name : t.name,
-                                                                         path : t.filepath,
+                                                                         name: t.name,
+                                                                         path: t.filepath,
                                                                        }));
   }
 
@@ -212,14 +212,14 @@ export class CMakeServerClientDriver extends CMakeDriver {
           });
           if (found) {
             const defs = (group.defines || []).map(util.parseCompileDefinition);
-            const defs_o = defs.reduce((acc, [ key, value ]) => ({...acc, [key] : value}), {});
-            const includes = (group.includePath || []).map(p => ({path : p.path, isSystem : p.isSystem || false}));
+            const defs_o = defs.reduce((acc, [key, value]) => ({...acc, [key]: value}), {});
+            const includes = (group.includePath || []).map(p => ({path: p.path, isSystem: p.isSystem || false}));
             const flags = util.splitCommandLine(group.compileFlags);
             return {
-              file : found,
-              compileDefinitions : defs_o,
-              compileFlags : flags,
-              includeDirectories : includes,
+              file: found,
+              compileDefinitions: defs_o,
+              compileFlags: flags,
+              includeDirectories: includes,
             };
           }
         }
@@ -245,14 +245,14 @@ export class CMakeServerClientDriver extends CMakeDriver {
 
   private async _startNewClient() {
     return cms.CMakeServerClient.start({
-      binaryDir : this.binaryDir,
-      sourceDir : this.sourceDir,
-      cmakePath : await paths.cmakePath,
-      environment : this.getKitEnvironmentVariablesObject(),
-      onDirty : async () => { this._dirty = true; },
-      onMessage : async msg => { this._onMessageEmitter.fire(msg.message); },
-      onProgress : async _prog => {},
-      pickGenerator : () => this.getBestGenerator(),
+      binaryDir: this.binaryDir,
+      sourceDir: this.sourceDir,
+      cmakePath: await paths.cmakePath,
+      environment: this.getKitEnvironmentVariablesObject(),
+      onDirty: async () => { this._dirty = true; },
+      onMessage: async msg => { this._onMessageEmitter.fire(msg.message); },
+      onProgress: async _prog => {},
+      pickGenerator: () => this.getBestGenerator(),
     });
   }
 

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -46,11 +46,11 @@ export class CMakeServerClientDriver extends CMakeDriver {
       // Stop the server before we try to rip out any old files
       await old_cl.shutdown();
       const build_dir = this.binaryDir;
-      const cache = this.cachePath;
+      const cache_path = this.cachePath;
       const cmake_files = path.join(build_dir, 'CMakeFiles');
-      if (await fs.exists(cache)) {
-        log.info('Removing', cache);
-        await fs.unlink(cache);
+      if (await fs.exists(cache_path)) {
+        log.info('Removing', cache_path);
+        await fs.unlink(cache_path);
       }
       if (await fs.exists(cmake_files)) {
         log.info('Removing', cmake_files);

--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -50,7 +50,7 @@ export function parseRawCompilationInfo(raw: RawCompilationInfo): CompilationInf
   }
 
   const unparsed_args: string[] = [];
-  arg = (n) => non_include_args[n];
+  arg = n => non_include_args[n];
   next_arg2: for (let i = 0; i < non_include_args.length; ++i) {
     for (const dflag of def_flags) {
       if (arg(i).startsWith(dflag)) {
@@ -83,7 +83,7 @@ export function parseCompileDefinition(str: string): [ string, string|null ] {
 }
 
 export class CompilationDatabase {
-  private _info_by_filepath: Map<string, CompilationInfo>;
+  private readonly _info_by_filepath: Map<string, CompilationInfo>;
   constructor(infos: CompilationInfo[]) {
     this._info_by_filepath = infos.reduce((acc, cur) => {
       acc.set(cur.file, cur);

--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -20,14 +20,14 @@ export function parseRawCompilationInfo(raw: RawCompilationInfo): CompilationInf
                      path: string;
                      isSystem: boolean
                    }[]);
-  const definitions = {} as {[key: string] : string | null};
+  const definitions = {} as {[key: string]: string | null};
 
-  const include_flags = [ {flag : '-I', isSystem : false}, {flag : '-isystem', isSystem : true} ];
-  const def_flags = [ '-D' ];
+  const include_flags = [{flag: '-I', isSystem: false}, {flag: '-isystem', isSystem: true}];
+  const def_flags = ['-D'];
   if (compiler.endsWith('cl.exe')) {
     // We are parsing an MSVC-style command line.
     // It has options which may appear with a different argument prefix.
-    include_flags.push({flag : '/I', isSystem : false});
+    include_flags.push({flag: '/I', isSystem: false});
     def_flags.push('/D');
   }
 
@@ -40,8 +40,8 @@ export function parseRawCompilationInfo(raw: RawCompilationInfo): CompilationInf
         const ipath = arg(i) === flagstr ? arg(++i) : arg(i).substr(flagstr.length);
         const abs_ipath = path.isAbsolute(ipath) ? ipath : path.join(raw.directory, ipath);
         inc_dirs.push({
-          path : util.normalizePath(abs_ipath),
-          isSystem : iflag.isSystem,
+          path: util.normalizePath(abs_ipath),
+          isSystem: iflag.isSystem,
         });
         continue next_arg;
       }
@@ -65,20 +65,20 @@ export function parseRawCompilationInfo(raw: RawCompilationInfo): CompilationInf
 
   return {
     compiler,
-    compile : raw,
-    compileDefinitions : definitions,
-    file : raw.file,
-    includeDirectories : inc_dirs,
-    compileFlags : unparsed_args,
+    compile: raw,
+    compileDefinitions: definitions,
+    file: raw.file,
+    includeDirectories: inc_dirs,
+    compileFlags: unparsed_args,
   };
 }
 
-export function parseCompileDefinition(str: string): [ string, string|null ] {
+export function parseCompileDefinition(str: string): [string, string|null] {
   if (/^\w+$/.test(str)) {
-    return [ str, null ];
+    return [str, null];
   } else {
     const key = str.split('=', 1)[0];
-    return [ key, str.substr(key.length + 1) ];
+    return [key, str.substr(key.length + 1)];
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,10 +41,10 @@ function readPrefixedConfig<T>(key: string): T|null;
 function readPrefixedConfig<T>(key: string, default_: T): T;
 function readPrefixedConfig<T>(key: string, default_?: T): T|null {
   const platmap = {
-    win32 : 'windows',
-    darwin : 'osx',
-    linux : 'linux',
-  } as {[k: string] : string};
+    win32: 'windows',
+    darwin: 'osx',
+    linux: 'linux',
+  } as {[k: string]: string};
   const platform = platmap[process.platform];
   if (default_ === undefined) {
     return readConfig(`${platform}.${key}`, readConfig<T>(`${key}`));
@@ -104,13 +104,13 @@ class ConfigurationReader {
 
   get debugConfig(): any { return readPrefixedConfig<any>('debugConfig'); }
 
-  get environment() { return readPrefixedConfig<{[key: string] : string}>('environment', {}); }
+  get environment() { return readPrefixedConfig<{[key: string]: string}>('environment', {}); }
 
-  get configureEnvironment() { return readPrefixedConfig<{[key: string] : string}>('configureEnvironment', {}); }
+  get configureEnvironment() { return readPrefixedConfig<{[key: string]: string}>('configureEnvironment', {}); }
 
-  get buildEnvironment() { return readPrefixedConfig<{[key: string] : string}>('buildEnvironment', {}); }
+  get buildEnvironment() { return readPrefixedConfig<{[key: string]: string}>('buildEnvironment', {}); }
 
-  get testEnvironment() { return readPrefixedConfig<{[key: string] : string}>('testEnvironment', {}); }
+  get testEnvironment() { return readPrefixedConfig<{[key: string]: string}>('testEnvironment', {}); }
 
   get defaultVariants(): Object { return readPrefixedConfig<Object>('defaultVariants', {}); }
 
@@ -152,7 +152,7 @@ class ConfigurationReader {
    * @param cb A callback when the setting changes
    */
   onChange<K extends keyof ConfigurationReader>(setting: K, cb: (value: ConfigurationReader[K]) => void) {
-    const state = {value : this[setting]};
+    const state = {value: this[setting]};
     return vscode.workspace.onDidChangeConfiguration(() => {
       rollbar.invoke(`Callback changing setting: cmake.${setting}`, () => {
         const new_value = this[setting];

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,8 +19,8 @@ export type LogLevelKey = 'trace'|'debug'|'info'|'note'|'warning'|'error'|'fatal
 function readConfig<T>(key: string): T|null;
 function readConfig<T>(key: string, default_: T): T;
 function readConfig<T>(key: string, default_?: T): T|null {
-  const config = vscode.workspace.getConfiguration('cmake');
-  const value = config.get(key) as T | undefined;
+  const cmt_config = vscode.workspace.getConfiguration('cmake');
+  const value = cmt_config.get(key) as T | undefined;
   if (value === undefined) {
     if (default_ === undefined) {
       return null;

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -152,7 +152,8 @@ export function parseCatchTestOutput(output: string): FailingTestDecoration[] {
     const res = regex.exec(line);
     if (res) {
       const [_all, file, lineno_] = res;
-      _all;  // unused
+      // tslint:disable-next-line
+      void _all; // unused
       const lineno = parseInt(lineno_) - 1;
       let message = '~~~c++\n';
       for (let i = 0;; ++i) {
@@ -369,7 +370,7 @@ export class CTestDriver implements vscode.Disposable {
               .result;
     if (result.retc !== 0) {
       // There was an error running CTest. Odd...
-      console.error('There was an error running ctest to determine available test executables');
+      log.error('There was an error running ctest to determine available test executables');
       return this.tests = [];
     }
     const tests = result.stdout.split('\n')

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -153,7 +153,7 @@ export function parseCatchTestOutput(output: string): FailingTestDecoration[] {
     if (res) {
       const [_all, file, lineno_] = res;
       // tslint:disable-next-line
-      void _all; // unused
+      void _all;  // unused
       const lineno = parseInt(lineno_) - 1;
       let message = '~~~c++\n';
       for (let i = 0;; ++i) {
@@ -282,7 +282,7 @@ class CTestOutputLogger implements OutputConsumer {
 };
 
 export class CTestDriver implements vscode.Disposable {
-  private _decorationManager = new DecorationManager();
+  private readonly _decorationManager = new DecorationManager();
   private _testingEnabled: boolean = false;
   get testingEnabled(): boolean { return this._testingEnabled; }
   set testingEnabled(v: boolean) {
@@ -398,7 +398,7 @@ export class CTestDriver implements vscode.Disposable {
     this.testResults = await readTestResultsFile(test_xml);
     const failing = this.testResults.Site.Testing.Test.filter(t => t.Status === 'failed');
     this._decorationManager.clearFailingTestDecorations();
-    let new_decors = [] as FailingTestDecoration[];
+    const new_decors = [] as FailingTestDecoration[];
     for (const t of failing) {
       new_decors.push(...await parseTestOutput(t.Output));
     }

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -115,20 +115,19 @@ function decodeOutputMeasurement(node: EncodedMeasurementValue|string): string {
 
 function cleanupResultsXML(messy: MessyResults): CTestResults {
   return {
-    Site : {
-      $ : messy.Site.$,
-      Testing : {
-        TestList : messy.Site.Testing[0].TestList.map(l => l.Test[0]),
-        Test :
-            messy.Site.Testing[0].Test.map((test): Test => ({
-                                             FullName : test.FullName[0],
-                                             FullCommandLine : test.FullCommandLine[0],
-                                             Name : test.Name[0],
-                                             Path : test.Path[0],
-                                             Status : test.$.Status,
-                                             Measurements : new Map<string, TestMeasurement>(),
-                                             Output : decodeOutputMeasurement(test.Results[0].Measurement[0].Value[0]),
-                                           }))
+    Site: {
+      $: messy.Site.$,
+      Testing: {
+        TestList: messy.Site.Testing[0].TestList.map(l => l.Test[0]),
+        Test: messy.Site.Testing[0].Test.map((test): Test => ({
+                                               FullName: test.FullName[0],
+                                               FullCommandLine: test.FullCommandLine[0],
+                                               Name: test.Name[0],
+                                               Path: test.Path[0],
+                                               Status: test.$.Status,
+                                               Measurements: new Map<string, TestMeasurement>(),
+                                               Output: decodeOutputMeasurement(test.Results[0].Measurement[0].Value[0]),
+                                             }))
       }
     }
   };
@@ -165,9 +164,9 @@ export function parseCatchTestOutput(output: string): FailingTestDecoration[] {
       }
 
       decorations.push({
-        fileName : file,
-        lineNumber : lineno,
-        hoverMessage : `${message}\n~~~`,
+        fileName: file,
+        lineNumber: lineno,
+        hoverMessage: `${message}\n~~~`,
       });
     }
   }
@@ -188,7 +187,7 @@ export class DecorationManager {
   }
 
   private readonly _failingTestDecorationType = vscode.window.createTextEditorDecorationType({
-    borderColor : 'rgba(255, 0, 0, 0.2)',
+    borderColor: 'rgba(255, 0, 0, 0.2)',
     borderWidth: '1px',
     borderRadius: '3px',
     borderStyle: 'solid',
@@ -246,8 +245,8 @@ export class DecorationManager {
                                      decor.lineNumber,
                                      file_line.range.end.character);
       fails_acc.push({
-        hoverMessage : decor.hoverMessage,
-        range : range,
+        hoverMessage: decor.hoverMessage,
+        range: range,
       });
     }
     editor.setDecorations(this._failingTestDecorationType, fails_acc);
@@ -335,10 +334,10 @@ export class CTestDriver implements vscode.Disposable {
     const configuration = driver.currentBuildType;
     const child
         = driver.executeCommand(await paths.ctestPath,
-                                [ `-j${config.numCTestJobs}`, '-C', configuration, '-T', 'test', '--output-on-failure' ]
+                                [`-j${config.numCTestJobs}`, '-C', configuration, '-T', 'test', '--output-on-failure']
                                     .concat(config.ctestArgs),
                                 new CTestOutputLogger(),
-                                {environment : config.testEnvironment, cwd : driver.binaryDir});
+                                {environment: config.testEnvironment, cwd: driver.binaryDir});
 
     const res = await child.result;
     await this.reloadTests(driver);
@@ -366,7 +365,7 @@ export class CTestDriver implements vscode.Disposable {
     const build_config = driver.currentBuildType;
     const result
         = await driver
-              .executeCommand('ctest', [ '-N', '-C', build_config ], undefined, {cwd : driver.binaryDir, silent : true})
+              .executeCommand('ctest', ['-N', '-C', build_config], undefined, {cwd: driver.binaryDir, silent: true})
               .result;
     if (result.retc !== 0) {
       // There was an error running CTest. Odd...
@@ -377,7 +376,7 @@ export class CTestDriver implements vscode.Disposable {
                       .map(l => l.trim())
                       .filter(l => /^Test\s*#(\d+):\s(.*)/.test(l))
                       .map(l => /^Test\s*#(\d+):\s(.*)/.exec(l)!)
-                      .map(([ _, id, tname ]) => ({id : parseInt(id!), name : tname!}));
+                      .map(([_, id, tname]) => ({id: parseInt(id!), name: tname!}));
     const tagfile = path.join(driver.binaryDir, 'Testing', 'TAG');
     const tag = (await fs.exists(tagfile)) ? (await fs.readFile(tagfile)).toString().split('\n')[0].trim() : null;
     const tagdir = tag ? path.join(driver.binaryDir, 'Testing', tag) : null;

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -139,7 +139,7 @@ export async function readTestResultsFile(test_xml: string) {
   const data = await parseXMLString(content) as MessyResults;
   const clean = cleanupResultsXML(data);
   return clean;
-};
+}
 
 
 export function parseCatchTestOutput(output: string): FailingTestDecoration[] {
@@ -180,7 +180,7 @@ export async function parseTestOutput(output: string): Promise<FailingTestDecora
   } else {
     return [];
   }
-};
+}
 
 export class DecorationManager {
   constructor() {
@@ -274,12 +274,12 @@ export class DecorationManager {
   //   this._coverageDecorations = v;
   //   this._refreshAllEditorDecorations();
   // }
-};
+}
 
 class CTestOutputLogger implements OutputConsumer {
   output(line: string) { log.info(line); }
   error(line: string) { this.output(line); }
-};
+}
 
 export class CTestDriver implements vscode.Disposable {
   private readonly _decorationManager = new DecorationManager();

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -363,10 +363,10 @@ export class CTestDriver implements vscode.Disposable {
     this._decorationManager.binaryDir = driver.binaryDir;
     this.testingEnabled = true;
 
-    const config = driver.currentBuildType;
+    const build_config = driver.currentBuildType;
     const result
         = await driver
-              .executeCommand('ctest', [ '-N', '-C', config ], undefined, {cwd : driver.binaryDir, silent : true})
+              .executeCommand('ctest', [ '-N', '-C', build_config ], undefined, {cwd : driver.binaryDir, silent : true})
               .result;
     if (result.retc !== 0) {
       // There was an error running CTest. Odd...

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -246,7 +246,7 @@ export class DecorationManager {
                                      file_line.range.end.character);
       fails_acc.push({
         hoverMessage: decor.hoverMessage,
-        range: range,
+        range,
       });
     }
     editor.setDecorations(this._failingTestDecorationType, fails_acc);

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -224,10 +224,9 @@ export class CompileOutputConsumer implements OutputConsumer {
   private readonly _gcc_re = /^(.*):(\d+):(\d+):\s+(?:fatal )?(\w*)(?:\sfatale)?\s?:\s+(.*)/;
   private readonly _gnu_ld_re = /^(.*):(\d+)\s?:\s+(.*[^\]])$/;
   private readonly _msvc_re
-      = /^\s*(?!\d+>)?\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+((?:fatal )?error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/
+      = /^\s*(?!\d+>)?\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+((?:fatal )?error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/;
 
-      private readonly _ghsDiagnostics: RawDiagnostic[]
-      = [];
+  private readonly _ghsDiagnostics: RawDiagnostic[] = [];
   get ghsDiagnostics() { return this._ghsDiagnostics; }
 
   private readonly _gccDiagnostics: RawDiagnostic[] = [];
@@ -377,20 +376,24 @@ export class CompileOutputConsumer implements OutputConsumer {
       GHS : this.ghsDiagnostics,
       link : this.gnuLDDiagnostics,
     };
-    const arrs = util.objectPairs(by_source).map(
-        ([ source, diags ]) => {return diags.map(raw_diag => {
-          const filepath = make_abs(raw_diag.file);
-          const diag = new vscode.Diagnostic(raw_diag.location, raw_diag.message, severity_of(raw_diag.severity));
-          diag.source = source;
-          if (raw_diag.code) {
-            diag.code = raw_diag.code;
-          }
-          if (!diags_by_file.has(filepath)) {
-            diags_by_file.set(filepath, []);
-          }
-          diags_by_file.get(filepath)!.push(diag);
-          return { filepath: filepath, diag: diag, }
-        })});
+    const arrs = util.objectPairs(by_source).map(([ source, diags ]) => {
+      return diags.map(raw_diag => {
+        const filepath = make_abs(raw_diag.file);
+        const diag = new vscode.Diagnostic(raw_diag.location, raw_diag.message, severity_of(raw_diag.severity));
+        diag.source = source;
+        if (raw_diag.code) {
+          diag.code = raw_diag.code;
+        }
+        if (!diags_by_file.has(filepath)) {
+          diags_by_file.set(filepath, []);
+        }
+        diags_by_file.get(filepath)!.push(diag);
+        return {
+          filepath : filepath,
+          diag : diag,
+        };
+      });
+    });
     return ([] as FileDiagnostic[]).concat(...arrs);
   }
 }
@@ -433,4 +436,4 @@ export class CMakeBuildConsumer implements OutputConsumer, vscode.Disposable {
       });
     }
   }
-};
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -137,12 +137,12 @@ export class CMakeOutputConsumer implements OutputConsumer {
         const [_full, level, filename, linestr, command] = result;
         // tslint:disable-next-line
         _full;  // unused
-        const line = Number.parseInt(linestr) - 1;
+        const lineno = Number.parseInt(linestr) - 1;
         const diagmap: {[k: string]: vscode.DiagnosticSeverity} = {
           'Warning' : vscode.DiagnosticSeverity.Warning,
           'Error' : vscode.DiagnosticSeverity.Error,
         };
-        const vsdiag = new vscode.Diagnostic(new vscode.Range(line, 0, line, 9999), '', diagmap[level]);
+        const vsdiag = new vscode.Diagnostic(new vscode.Range(lineno, 0, lineno, 9999), '', diagmap[level]);
         vsdiag.source = `CMake (${command})`;
         const filepath = path.isAbsolute(filename) ? filename : util.normalizePath(path.join(this.sourceDir, filename));
         this._errorState.diag = {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -76,7 +76,7 @@ export class CMakeOutputConsumer implements OutputConsumer {
    * during calls to `output()` and `error()`
    */
   get diagnostics() { return this._diagnostics; }
-  private _diagnostics = [] as FileDiagnostic[];
+  private readonly _diagnostics = [] as FileDiagnostic[];
 
   /**
    * Simply writes the line of output to the log
@@ -90,7 +90,7 @@ export class CMakeOutputConsumer implements OutputConsumer {
   /**
    * The state for the diagnostic parser. Implemented as a crude FSM
    */
-  private _errorState: {
+  private readonly _errorState: {
     /**
      * The state of the parser. `init` is the rest state. `diag` is the state
      * of active parsing. `stack` is parsing the CMake call stack from an error
@@ -226,17 +226,17 @@ export class CompileOutputConsumer implements OutputConsumer {
   private readonly _msvc_re
       = /^\s*(?!\d+>)?\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+((?:fatal )?error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/
 
-      private _ghsDiagnostics: RawDiagnostic[]
+      private readonly _ghsDiagnostics: RawDiagnostic[]
       = [];
   get ghsDiagnostics() { return this._ghsDiagnostics; }
 
-  private _gccDiagnostics: RawDiagnostic[] = [];
+  private readonly _gccDiagnostics: RawDiagnostic[] = [];
   get gccDiagnostics() { return this._gccDiagnostics; }
 
-  private _gnuLDDiagnostics: RawDiagnostic[] = [];
+  private readonly _gnuLDDiagnostics: RawDiagnostic[] = [];
   get gnuLDDiagnostics() { return this._gnuLDDiagnostics; }
 
-  private _msvcDiagnostics: RawDiagnostic[] = [];
+  private readonly _msvcDiagnostics: RawDiagnostic[] = [];
   get msvcDiagnostics() { return this._msvcDiagnostics; }
 
   private _tryParseLD(line: string): RawDiagnostic|null {
@@ -378,7 +378,7 @@ export class CompileOutputConsumer implements OutputConsumer {
       link : this.gnuLDDiagnostics,
     };
     const arrs = util.objectPairs(by_source).map(
-        ([ source, diags ]) => {return diags.map((raw_diag) => {
+        ([ source, diags ]) => {return diags.map(raw_diag => {
           const filepath = make_abs(raw_diag.file);
           const diag = new vscode.Diagnostic(raw_diag.location, raw_diag.message, severity_of(raw_diag.severity));
           diag.source = source;
@@ -408,8 +408,8 @@ export class CMakeBuildConsumer implements OutputConsumer, vscode.Disposable {
    * Event fired when the progress changes
    */
   get onProgress() { return this._onProgressEmitter.event; }
-  private _onProgressEmitter = new vscode.EventEmitter<proc.ProgressData>();
-  private _percent_re = /\[.*?(\d+)\%.*?\]/;
+  private readonly _onProgressEmitter = new vscode.EventEmitter<proc.ProgressData>();
+  private readonly _percent_re = /\[.*?(\d+)\%.*?\]/;
 
   readonly compileConsumer = new CompileOutputConsumer();
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -9,7 +9,7 @@ import {RawDiagnostic} from './diagnostics';
 import * as logging from './logging';
 import * as proc from './proc';
 import {OutputConsumer} from './proc';
-import * as util from "./util";
+import * as util from './util';
 
 const cmake_logger = logging.createLogger('cmake');
 const build_logger = logging.createLogger('build');
@@ -110,7 +110,7 @@ export class CMakeOutputConsumer implements OutputConsumer {
     blankLines: number,
   }
   = {
-      state : 'init',
+      state: 'init',
       diag: null,
       blankLines: 0,
     };
@@ -139,15 +139,15 @@ export class CMakeOutputConsumer implements OutputConsumer {
         _full;  // unused
         const lineno = Number.parseInt(linestr) - 1;
         const diagmap: {[k: string]: vscode.DiagnosticSeverity} = {
-          'Warning' : vscode.DiagnosticSeverity.Warning,
-          'Error' : vscode.DiagnosticSeverity.Error,
+          'Warning': vscode.DiagnosticSeverity.Warning,
+          'Error': vscode.DiagnosticSeverity.Error,
         };
         const vsdiag = new vscode.Diagnostic(new vscode.Range(lineno, 0, lineno, 9999), '', diagmap[level]);
         vsdiag.source = `CMake (${command})`;
         const filepath = path.isAbsolute(filename) ? filename : util.normalizePath(path.join(this.sourceDir, filename));
         this._errorState.diag = {
           filepath,
-          diag : vsdiag,
+          diag: vsdiag,
         };
         this._errorState.state = 'diag';
         this._errorState.blankLines = 0;
@@ -254,11 +254,11 @@ export class CompileOutputConsumer implements OutputConsumer {
     const [full, file, lineno, message] = res;
     if (file && lineno && message) {
       return {
-        full : full,
-        file : file,
-        location : new vscode.Range(parseInt(lineno) - 1, 0, parseInt(lineno) - 1, 999),
-        severity : 'error',
-        message : message,
+        full: full,
+        file: file,
+        location: new vscode.Range(parseInt(lineno) - 1, 0, parseInt(lineno) - 1, 999),
+        severity: 'error',
+        message: message,
       };
     } else {
       return null;
@@ -288,12 +288,12 @@ export class CompileOutputConsumer implements OutputConsumer {
       throw new Error('Unable to determine location of MSVC diagnostic');
     })();
     return {
-      full : full,
-      file : file,
-      location : range,
-      severity : severity,
-      message : message,
-      code : code,
+      full: full,
+      file: file,
+      location: range,
+      severity: severity,
+      message: message,
+      code: code,
     };
   }
 
@@ -305,11 +305,11 @@ export class CompileOutputConsumer implements OutputConsumer {
         const [full, file, lineno, column, severity, message] = gcc_mat;
         if (file && lineno && column && severity && message) {
           this._gccDiagnostics.push({
-            full : full,
-            file : file,
-            location : new vscode.Range(parseInt(lineno) - 1, parseInt(column) - 1, parseInt(lineno) - 1, 999),
-            severity : severity,
-            message : message,
+            full: full,
+            file: file,
+            location: new vscode.Range(parseInt(lineno) - 1, parseInt(column) - 1, parseInt(lineno) - 1, 999),
+            severity: severity,
+            message: message,
           });
           return;
         }
@@ -323,11 +323,11 @@ export class CompileOutputConsumer implements OutputConsumer {
         const [full, file, lineno = '1', column = '1', severity, message] = ghs_mat;
         if (file && severity && message) {
           this._ghsDiagnostics.push({
-            full : full,
-            file : file,
-            location : new vscode.Range(parseInt(lineno) - 1, parseInt(column) - 1, parseInt(lineno) - 1, 999),
-            severity : severity,
-            message : message
+            full: full,
+            file: file,
+            location: new vscode.Range(parseInt(lineno) - 1, parseInt(column) - 1, parseInt(lineno) - 1, 999),
+            severity: severity,
+            message: message
           });
           return;
         }
@@ -371,12 +371,12 @@ export class CompileOutputConsumer implements OutputConsumer {
     };
 
     const by_source = {
-      GCC : this.gccDiagnostics,
-      MSVC : this.msvcDiagnostics,
-      GHS : this.ghsDiagnostics,
-      link : this.gnuLDDiagnostics,
+      GCC: this.gccDiagnostics,
+      MSVC: this.msvcDiagnostics,
+      GHS: this.ghsDiagnostics,
+      link: this.gnuLDDiagnostics,
     };
-    const arrs = util.objectPairs(by_source).map(([ source, diags ]) => {
+    const arrs = util.objectPairs(by_source).map(([source, diags]) => {
       return diags.map(raw_diag => {
         const filepath = make_abs(raw_diag.file);
         const diag = new vscode.Diagnostic(raw_diag.location, raw_diag.message, severity_of(raw_diag.severity));
@@ -389,8 +389,8 @@ export class CompileOutputConsumer implements OutputConsumer {
         }
         diags_by_file.get(filepath)!.push(diag);
         return {
-          filepath : filepath,
-          diag : diag,
+          filepath: filepath,
+          diag: diag,
         };
       });
     });
@@ -430,9 +430,9 @@ export class CMakeBuildConsumer implements OutputConsumer, vscode.Disposable {
     if (progress) {
       const percent = progress[1];
       this._onProgressEmitter.fire({
-        minimum : 0,
-        maximum : 100,
-        value : Number.parseInt(percent),
+        minimum: 0,
+        maximum: 100,
+        value: Number.parseInt(percent),
       });
     }
   }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -135,6 +135,7 @@ export class CMakeOutputConsumer implements OutputConsumer {
       if (result) {
         // We have encountered and error
         const [_full, level, filename, linestr, command] = result;
+        // tslint:disable-next-line
         _full;  // unused
         const line = Number.parseInt(linestr) - 1;
         const diagmap: {[k: string]: vscode.DiagnosticSeverity} = {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -254,11 +254,11 @@ export class CompileOutputConsumer implements OutputConsumer {
     const [full, file, lineno, message] = res;
     if (file && lineno && message) {
       return {
-        full: full,
-        file: file,
+        full,
+        file,
         location: new vscode.Range(parseInt(lineno) - 1, 0, parseInt(lineno) - 1, 999),
         severity: 'error',
-        message: message,
+        message,
       };
     } else {
       return null;
@@ -288,12 +288,12 @@ export class CompileOutputConsumer implements OutputConsumer {
       throw new Error('Unable to determine location of MSVC diagnostic');
     })();
     return {
-      full: full,
-      file: file,
+      full,
+      file,
       location: range,
-      severity: severity,
-      message: message,
-      code: code,
+      severity,
+      message,
+      code,
     };
   }
 
@@ -305,11 +305,11 @@ export class CompileOutputConsumer implements OutputConsumer {
         const [full, file, lineno, column, severity, message] = gcc_mat;
         if (file && lineno && column && severity && message) {
           this._gccDiagnostics.push({
-            full: full,
-            file: file,
+            full,
+            file,
             location: new vscode.Range(parseInt(lineno) - 1, parseInt(column) - 1, parseInt(lineno) - 1, 999),
-            severity: severity,
-            message: message,
+            severity,
+            message,
           });
           return;
         }
@@ -323,11 +323,11 @@ export class CompileOutputConsumer implements OutputConsumer {
         const [full, file, lineno = '1', column = '1', severity, message] = ghs_mat;
         if (file && severity && message) {
           this._ghsDiagnostics.push({
-            full: full,
-            file: file,
+            full,
+            file,
             location: new vscode.Range(parseInt(lineno) - 1, parseInt(column) - 1, parseInt(lineno) - 1, 999),
-            severity: severity,
-            message: message
+            severity,
+            message
           });
           return;
         }
@@ -389,8 +389,8 @@ export class CompileOutputConsumer implements OutputConsumer {
         }
         diags_by_file.get(filepath)!.push(diag);
         return {
-          filepath: filepath,
-          diag: diag,
+          filepath,
+          diag,
         };
       });
     });

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -139,8 +139,8 @@ export class CMakeOutputConsumer implements OutputConsumer {
         _full;  // unused
         const lineno = Number.parseInt(linestr) - 1;
         const diagmap: {[k: string]: vscode.DiagnosticSeverity} = {
-          'Warning': vscode.DiagnosticSeverity.Warning,
-          'Error': vscode.DiagnosticSeverity.Error,
+          Warning: vscode.DiagnosticSeverity.Warning,
+          Error: vscode.DiagnosticSeverity.Error,
         };
         const vsdiag = new vscode.Diagnostic(new vscode.Range(lineno, 0, lineno, 9999), '', diagmap[level]);
         vsdiag.source = `CMake (${command})`;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -251,6 +251,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       } else {
         this._kitEnvironmentVariables = vars;
       }
+      break;
     }
     default: {
       // Other kits don't have environment variables

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -466,7 +466,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
         if (gen.name.toLowerCase().startsWith('xcode') && platform === 'darwin') {
           return gen;
         }
-        vscode.window.showErrorMessage('Unknown CMake generator "' + gen.name + '"');
+        vscode.window.showErrorMessage(`Unknown CMake generator "${gen.name}"`);
         continue;
       } else {
         return gen;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -442,17 +442,17 @@ export abstract class CMakeDriver implements vscode.Disposable {
       const gen_name = gen.name;
       const generator_present = await (async(): Promise<boolean> => {
         if (gen_name == 'Ninja') {
-          return await this.testHaveCommand('ninja-build') || await this.testHaveCommand('ninja');
+          return await this.testHaveCommand('ninja-build') || this.testHaveCommand('ninja');
         }
         if (gen_name == 'MinGW Makefiles') {
           return platform === 'win32' && await this.testHaveCommand('make')
-              || await this.testHaveCommand('mingw32-make');
+              || this.testHaveCommand('mingw32-make');
         }
         if (gen_name == 'NMake Makefiles') {
-          return platform === 'win32' && await this.testHaveCommand('nmake', [ '/?' ]);
+          return platform === 'win32' && this.testHaveCommand('nmake', [ '/?' ]);
         }
         if (gen_name == 'Unix Makefiles') {
-          return platform !== 'win32' && await this.testHaveCommand('make');
+          return platform !== 'win32' && this.testHaveCommand('make');
         }
         return false;
       })();

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -96,16 +96,14 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Get the environment variables required by the current Kit
    */
   getKitEnvironmentVariablesObject(): proc.EnvironmentVariables {
-    return util.reduce(this._kitEnvironmentVariables.entries(),
-                       {},
-                       (acc, [ key, value ]) => Object.assign(acc, {[key] : value}));
+    return util.reduce(this._kitEnvironmentVariables.entries(), {}, (acc, [ key, value ]) => ({...acc, [key] : value}));
   }
 
   /**
    * Event fired when the name of the CMake project is discovered or changes
    */
   get onProjectNameChanged() { return this._projectNameChangedEmitter.event; }
-  private _projectNameChangedEmitter = new vscode.EventEmitter<string>();
+  private readonly _projectNameChangedEmitter = new vscode.EventEmitter<string>();
 
   public get projectName(): string { return this.stateManager.projectName || 'Unknown Project'; }
   protected doSetProjectName(v: string) {
@@ -183,7 +181,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     while ((mat = var_re.exec(instr))) {
       const full = mat[0];
       const key = mat[1];
-      let repl = replacements[key];
+      const repl = replacements[key];
       if (!repl) {
         log.warning(`Invalid variable reference ${full} in string: ${instr}`);
       } else {
@@ -223,7 +221,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const env = util.mergeEnvironment(cur_env,
                                       this.getKitEnvironmentVariablesObject(),
                                       (options && options.environment) ? options.environment : {});
-    const exec_options = Object.assign({}, options, {environment : env});
+    const exec_options = {...options, environment : env};
     return proc.execute(command, args, consumer, exec_options);
   }
 
@@ -238,7 +236,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
   }
 
   private async _setKit(kit: Kit): Promise<void> {
-    this._kit = Object.seal(Object.assign({}, kit));
+    this._kit = Object.seal({...kit});
     log.debug('CMakeDriver Kit set to', kit.name);
 
     this._kitEnvironmentVariables = new Map();
@@ -446,8 +444,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
           return await this.testHaveCommand('ninja-build') || this.testHaveCommand('ninja');
         }
         if (gen_name == 'MinGW Makefiles') {
-          return platform === 'win32' && await this.testHaveCommand('make')
-              || this.testHaveCommand('mingw32-make');
+          return platform === 'win32' && await this.testHaveCommand('make') || this.testHaveCommand('mingw32-make');
         }
         if (gen_name == 'NMake Makefiles') {
           return platform === 'win32' && this.testHaveCommand('nmake', [ '/?' ]);
@@ -478,7 +475,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     return null;
   }
 
-  private _onReconfiguredEmitter = new vscode.EventEmitter<void>();
+  private readonly _onReconfiguredEmitter = new vscode.EventEmitter<void>();
   get onReconfigured(): vscode.Event<void> { return this._onReconfiguredEmitter.event; }
 
   async configure(extra_args: string[], consumer?: proc.OutputConsumer): Promise<number> {
@@ -487,7 +484,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       return -1;
     }
 
-    const settings = Object.assign({}, config.configureSettings);
+    const settings = {...config.configureSettings};
 
     const _makeFlag = (key: string, cmval: util.CMakeValue) => {
       switch (cmval.type) {

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -323,7 +323,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
   /**
    * Directory where build output is stored.
    */
-  get binaryDir(): string { return this._binaryDir }
+  get binaryDir(): string { return this._binaryDir; }
   private _binaryDir = '';
 
   /**

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -13,9 +13,9 @@ import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
 import rollbar from './rollbar';
-import {StateManager} from "./state";
+import {StateManager} from './state';
 import * as util from './util';
-import {ConfigureArguments, VariantConfigurationOptions} from "./variant";
+import {ConfigureArguments, VariantConfigurationOptions} from './variant';
 
 const log = logging.createLogger('driver');
 
@@ -96,7 +96,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Get the environment variables required by the current Kit
    */
   getKitEnvironmentVariablesObject(): proc.EnvironmentVariables {
-    return util.reduce(this._kitEnvironmentVariables.entries(), {}, (acc, [ key, value ]) => ({...acc, [key] : value}));
+    return util.reduce(this._kitEnvironmentVariables.entries(), {}, (acc, [key, value]) => ({...acc, [key]: value}));
   }
 
   /**
@@ -161,15 +161,15 @@ export abstract class CMakeDriver implements vscode.Disposable {
    */
   async expandString(instr: string): Promise<string> {
     const ws_root = util.normalizePath(vscode.workspace.rootPath || '.');
-    type StringObject = {[key: string] : string | undefined};
+    type StringObject = {[key: string]: string | undefined};
     const user_dir = process.platform === 'win32' ? process.env['PROFILE']! : process.env['HOME']!;
     const replacements: StringObject = {
-      workspaceRoot : vscode.workspace.rootPath,
-      buildType : this.currentBuildType,
-      workspaceRootFolderName : path.basename(ws_root),
-      generator : this.generatorName || 'null',
-      projectName : this.projectName,
-      userHome : user_dir,
+      workspaceRoot: vscode.workspace.rootPath,
+      buildType: this.currentBuildType,
+      workspaceRootFolderName: path.basename(ws_root),
+      generator: this.generatorName || 'null',
+      projectName: this.projectName,
+      userHome: user_dir,
     };
 
     // We accumulate a list of substitutions that we need to make, preventing
@@ -221,7 +221,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const env = util.mergeEnvironment(cur_env,
                                       this.getKitEnvironmentVariablesObject(),
                                       (options && options.environment) ? options.environment : {});
-    const exec_options = {...options, environment : env};
+    const exec_options = {...options, environment: env};
     return proc.execute(command, args, consumer, exec_options);
   }
 
@@ -364,7 +364,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    */
   get compilerID(): string|null {
     const entries = this.cmakeCacheEntries;
-    const languages = [ 'CXX', 'C', 'CUDA' ];
+    const languages = ['CXX', 'C', 'CUDA'];
     for (const lang of languages) {
       const entry = entries.get(`CMAKE_${lang}_COMPILER`);
       if (!entry) {
@@ -397,8 +397,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
     return null;
   }
 
-  private async testHaveCommand(program: string, args: string[] = [ '--version' ]): Promise<boolean> {
-    const child = this.executeCommand(program, args, undefined, {silent : true});
+  private async testHaveCommand(program: string, args: string[] = ['--version']): Promise<boolean> {
+    const child = this.executeCommand(program, args, undefined, {silent: true});
     try {
       await child.result;
       return true;
@@ -412,7 +412,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
   }
 
   getPreferredGenerators(): CMakeGenerator[] {
-    const user_preferred = config.preferredGenerators.map(g => ({name : g}));
+    const user_preferred = config.preferredGenerators.map(g => ({name: g}));
     if (this._kit && this._kit.preferredGenerator) {
       // The kit has a preferred generator attached as well
       user_preferred.push(this._kit.preferredGenerator);
@@ -429,12 +429,12 @@ export abstract class CMakeDriver implements vscode.Disposable {
     if (user_generator) {
       log.debug(`Using generator from user configuration: ${user_generator}`);
       return {
-        name : user_generator,
-        platform : config.platform || undefined,
-        toolset : config.toolset || undefined,
+        name: user_generator,
+        platform: config.platform || undefined,
+        toolset: config.toolset || undefined,
       };
     }
-    log.debug("Trying to detect generator supported by system");
+    log.debug('Trying to detect generator supported by system');
     const platform = process.platform;
     const candidates = this.getPreferredGenerators();
     for (const gen of candidates) {
@@ -447,7 +447,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
           return platform === 'win32' && await this.testHaveCommand('make') || this.testHaveCommand('mingw32-make');
         }
         if (gen_name == 'NMake Makefiles') {
-          return platform === 'win32' && this.testHaveCommand('nmake', [ '/?' ]);
+          return platform === 'win32' && this.testHaveCommand('nmake', ['/?']);
         }
         if (gen_name == 'Unix Makefiles') {
           return platform !== 'win32' && this.testHaveCommand('make');
@@ -458,9 +458,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
         const vsMatch = /^(Visual Studio \d{2} \d{4})($|\sWin64$|\sARM$)/.exec(gen.name);
         if (platform === 'win32' && vsMatch) {
           return {
-            name : vsMatch[1],
-            platform : gen.platform || vsMatch[2],
-            toolset : gen.toolset,
+            name: vsMatch[1],
+            platform: gen.platform || vsMatch[2],
+            toolset: gen.toolset,
           };
         }
         if (gen.name.toLowerCase().startsWith('xcode') && platform === 'darwin') {
@@ -495,7 +495,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       }
     };
 
-    util.objectPairs(this._variantConfigureSettings).forEach(([ key, value ]) => settings[key] = value);
+    util.objectPairs(this._variantConfigureSettings).forEach(([key, value]) => settings[key] = value);
     if (this._variantLinkage !== null) {
       settings.BUILD_SHARED_LIBS = this._variantLinkage === 'shared';
     }
@@ -509,8 +509,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
     }
 
     const settings_flags
-        = util.objectPairs(settings).map(([ key, value ]) => _makeFlag(key, util.cmakeify(value as string)));
-    const flags = [ '--no-warn-unused-cli' ].concat(extra_args);
+        = util.objectPairs(settings).map(([key, value]) => _makeFlag(key, util.cmakeify(value as string)));
+    const flags = ['--no-warn-unused-cli'].concat(extra_args);
 
     console.assert(!!this._kit);
     if (!this._kit) {
@@ -520,8 +520,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     case 'compilerKit': {
       log.debug('Using compilerKit', this._kit.name, 'for usage');
       flags.push(
-          ...util.objectPairs(this._kit.compilers).map(([ lang,
-                                                          comp ]) => `-DCMAKE_${lang}_COMPILER:FILEPATH=${comp}`));
+          ...util.objectPairs(this._kit.compilers).map(([lang, comp]) => `-DCMAKE_${lang}_COMPILER:FILEPATH=${comp}`));
     } break;
     case 'toolchainKit': {
       log.debug('Using CMake toolchain', this._kit.name, 'for configuring');
@@ -532,8 +531,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     }
 
     if (this._kit.cmakeSettings) {
-      flags.push(
-          ...util.objectPairs(this._kit.cmakeSettings).map(([ key, val ]) => _makeFlag(key, util.cmakeify(val))));
+      flags.push(...util.objectPairs(this._kit.cmakeSettings).map(([key, val]) => _makeFlag(key, util.cmakeify(val))));
     }
 
     const final_flags = flags.concat(settings_flags);
@@ -600,12 +598,12 @@ export abstract class CMakeDriver implements vscode.Disposable {
         const chosen = await vscode.window.showErrorMessage<
             vscode.MessageItem>('Not all open documents were saved. Would you like to continue anyway?',
                                 {
-                                  title : 'Yes',
-                                  isCloseAffordance : false,
+                                  title: 'Yes',
+                                  isCloseAffordance: false,
                                 },
                                 {
-                                  title : 'No',
-                                  isCloseAffordance : true,
+                                  title: 'No',
+                                  isCloseAffordance: true,
                                 });
         return chosen !== undefined && (chosen.title === 'Yes');
       }
@@ -630,7 +628,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       if (!gen)
         return [];
       else if (/(Unix|MinGW) Makefiles|Ninja/.test(gen) && target !== 'clean')
-        return [ '-j', config.numJobs.toString() ];
+        return ['-j', config.numJobs.toString()];
       else if (gen.includes('Visual Studio'))
         return [
           '/m',
@@ -639,8 +637,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
       else
         return [];
     })();
-    const args = [ '--build', this.binaryDir, '--config', this.currentBuildType, '--target', target, '--' ].concat(
-        generator_args);
+    const args =
+        ['--build', this.binaryDir, '--config', this.currentBuildType, '--target', target, '--'].concat(generator_args);
     const cmake = await paths.cmakePath;
     const child = this.executeCommand(cmake, args, consumer);
     this._currentProcess = child;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,9 +34,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<CMakeT
     return vscode.commands.registerCommand('cmake.' + name, () => {
       const id = util.randint(1000, 10000);
       return rollbar.invokeAsync(name, async () => {
-        const cmt = await cmt_pr;
+        const cmt_inst = await cmt_pr;
         log.debug(`[${id}]`, 'cmake.' + name, 'started');
-        const fn = (cmt[name] as Function).bind(cmt);
+        const fn = (cmt_inst[name] as Function).bind(cmt_inst);
         await fn();
         log.debug(`[${id}]`, 'cmake.' + name, 'finished');
       });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,14 +31,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<CMakeT
 
   // A register function helps us bind the commands to the extension
   function register<K extends keyof CMakeTools>(name: K) {
-    return vscode.commands.registerCommand('cmake.' + name, () => {
+    return vscode.commands.registerCommand(`cmake.${name}`, () => {
       const id = util.randint(1000, 10000);
       return rollbar.invokeAsync(name, async () => {
         const cmt_inst = await cmt_pr;
-        log.debug(`[${id}]`, 'cmake.' + name, 'started');
+        log.debug(`[${id}]`, `cmake.${name}`, 'started');
         const fn = (cmt_inst[name] as Function).bind(cmt_inst);
         await fn();
-        log.debug(`[${id}]`, 'cmake.' + name, 'finished');
+        log.debug(`[${id}]`, `cmake.${name}`, 'finished');
       });
     });
   }
@@ -66,7 +66,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<CMakeT
   // Push it so we get clean teardown.
   context.subscriptions.push(cmt);
 
-  context.subscriptions.push(vscode.commands.registerCommand('cmake._extensionInstance', () => { return cmt; }));
+  context.subscriptions.push(vscode.commands.registerCommand('cmake._extensionInstance', () => cmt));
 
   // Return the extension
   INSTANCE = cmt;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -483,11 +483,11 @@ export async function scanForKits() {
                       // Search directories on `PATH` for compiler binaries
                       const pathvar = process.env['PATH'] !;
                       const sep = isWin32 ? ';' : ':';
-                      const paths = pathvar.split(sep);
+                      const path_elems = pathvar.split(sep);
 
                       // Search them all in parallel
                       let prs = [] as Promise<Kit[]>[];
-                      const compiler_kits = paths.map(path => scanDirForCompilerKits(path, pr));
+                      const compiler_kits = path_elems.map(path_el => scanDirForCompilerKits(path_el, pr));
                       prs = prs.concat(compiler_kits);
                       if(isWin32) {
                         const vs_kits = scanForVSKits(pr);
@@ -497,7 +497,6 @@ export async function scanForKits() {
                       const kits = ([] as Kit[]).concat(...arrays);
                       kits.map(k => log.info(`Found Kit: ${k.name}`));
                       return kits;
-
                     });
 }
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -798,7 +798,7 @@ export class KitManager implements vscode.Disposable {
   async openKitsEditor() {
     log.debug('Opening TextEditor for', this._kitsPath);
     const text = await vscode.workspace.openTextDocument(this._kitsPath);
-    return await vscode.window.showTextDocument(text);
+    return vscode.window.showTextDocument(text);
   }
 }
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -60,7 +60,7 @@ export interface CompilerKit extends BaseKit {
    * The key `lang` is the language, as in `CMAKE_<lang>_COMPILER`.
    * The corresponding value is a path to a compiler for that language.
    */
-  compilers: {[lang: string]: string}
+  compilers: {[lang: string]: string};
 }
 
 /**
@@ -243,16 +243,14 @@ export async function scanDirForCompilerKits(dir: string, pr?: ProgressReporter)
                 "isDirectory",
                 stat.isDirectory(),
                 "isSymbolicLink",
-                stat.isSymbolicLink())
+                stat.isSymbolicLink());
       if (e.code == 'EACCES') {
         // The binary may not be executable by this user...
         return null;
-      }
-      else if (e.code == 'ENOENT') {
+      } else if (e.code == 'ENOENT') {
         // This will happen on Windows if we try to "execute" a directory
         return null;
-      }
-      else if (e.code == "UNKNOWN" && process.platform == "win32") {
+      } else if (e.code == "UNKNOWN" && process.platform == "win32") {
         // This is when file is not executable (in windows)
         return null;
       }
@@ -297,7 +295,7 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   for (const inst of vs_installs) {
     if (inst_ids.indexOf(inst.instanceId) < 0) {
       installs.push(inst);
-      inst_ids.push(inst.instanceId)
+      inst_ids.push(inst.instanceId);
     }
   }
   return installs;
@@ -616,7 +614,7 @@ export class KitManager implements vscode.Disposable {
     }
 
     interface KitItem extends vscode.QuickPickItem {
-      kit: Kit
+      kit: Kit;
     }
     log.debug('Opening kit selection QuickPick');
     const items = this._kits.map((kit): KitItem => {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -411,7 +411,7 @@ async function varsForVSInstallation(inst: VSInstallation, arch: string): Promis
 async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?: ProgressReporter):
     Promise<VSKit|null> {
   const installName = inst.displayName || inst.instanceId;
-  const name = installName + ' - ' + arch;
+  const name = `${installName} - ${arch}`;
   log.debug('Checking for kit: ' + name);
   if (pr) {
     pr.report({message: `Checking ${installName} with ${arch}`});

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -349,7 +349,7 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
   const batpath = path.join(paths.tmpDir, `vs-cmt-${fname}`);
   await fs.writeFile(batpath, bat.join('\r\n'));
   const res = await proc.execute(batpath, [], null, {shell : true}).result;
-  fs.unlink(batpath);
+  await fs.unlink(batpath);
   const output = res.stdout;
   if (res.retc !== 0) {
     console.log(`Error running ${devbat}`, output);
@@ -368,7 +368,7 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
           if (mat) {
             acc.set(mat[1], mat[2]);
           } else {
-            console.error(`Error parsing environment variable: ${line}`);
+            log.error(`Error parsing environment variable: ${line}`);
           }
           return acc;
         }, new Map());
@@ -787,7 +787,7 @@ export class KitManager implements vscode.Disposable {
         return;
       }
       if (item.doOpen) {
-        this.openKitsEditor();
+        await this.openKitsEditor();
       }
     }
   }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -10,9 +10,9 @@ import * as logging from './logging';
 import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
-import {loadSchema} from "./schema";
+import {loadSchema} from './schema';
 import {StateManager} from './state';
-import {dropNulls, thisExtensionPath} from "./util";
+import {dropNulls, thisExtensionPath} from './util';
 
 const log = logging.createLogger('kit');
 
@@ -119,8 +119,8 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
   if (gcc_res) {
     log.debug('Testing GCC-ish binary:', bin);
     if (pr)
-      pr.report({message : `Getting GCC version for ${bin}`});
-    const exec = await proc.execute(bin, [ '-v' ]).result;
+      pr.report({message: `Getting GCC version for ${bin}`});
+    const exec = await proc.execute(bin, ['-v']).result;
     if (exec.retc != 0) {
       return null;
     }
@@ -137,27 +137,27 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
     log.debug('Detected GCC compiler kit:', bin);
     if (await fs.exists(gxx_bin)) {
       return {
-        type : 'compilerKit',
-        name : name,
-        compilers : {
-          'CXX' : gxx_bin,
-          'C' : bin,
+        type: 'compilerKit',
+        name: name,
+        compilers: {
+          'CXX': gxx_bin,
+          'C': bin,
         }
       };
     } else {
       return {
-        type : 'compilerKit',
-        name : name,
-        compilers : {
-          'C' : bin,
+        type: 'compilerKit',
+        name: name,
+        compilers: {
+          'C': bin,
         }
       };
     }
   } else if (clang_res) {
     log.debug('Testing Clang-ish binary:', bin);
     if (pr)
-      pr.report({message : `Getting Clang version for ${bin}`});
-    const exec = await proc.execute(bin, [ '-v' ]).result;
+      pr.report({message: `Getting Clang version for ${bin}`});
+    const exec = await proc.execute(bin, ['-v']).result;
     if (exec.retc != 0) {
       return null;
     }
@@ -174,19 +174,19 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
     log.debug('Detected Clang compiler kit:', bin);
     if (await fs.exists(clangxx_bin)) {
       return {
-        type : 'compilerKit',
-        name : name,
-        compilers : {
-          'C' : bin,
-          'CXX' : clangxx_bin,
+        type: 'compilerKit',
+        name: name,
+        compilers: {
+          'C': bin,
+          'CXX': clangxx_bin,
         },
       };
     } else {
       return {
-        type : 'compilerKit',
-        name : name,
-        compilers : {
-          'C' : bin,
+        type: 'compilerKit',
+        name: name,
+        compilers: {
+          'C': bin,
         },
       };
     }
@@ -223,7 +223,7 @@ export async function scanDirForCompilerKits(dir: string, pr?: ProgressReporter)
   }
   // Get files in the directory
   if (pr)
-    pr.report({message : `Checking ${dir} for compilers...`});
+    pr.report({message: `Checking ${dir} for compilers...`});
   const bins = (await fs.readdir(dir)).map(f => path.join(dir, f));
   // Scan each binary in parallel
   const prs = bins.map(async bin => {
@@ -235,14 +235,14 @@ export async function scanDirForCompilerKits(dir: string, pr?: ProgressReporter)
 
       log.warning('Failed to check binary', bin, 'by exception:', e);
       const stat = await fs.stat(bin);
-      log.debug("File infos: ",
-                "Mode",
+      log.debug('File infos: ',
+                'Mode',
                 stat.mode,
-                "isFile",
+                'isFile',
                 stat.isFile(),
-                "isDirectory",
+                'isDirectory',
                 stat.isDirectory(),
-                "isSymbolicLink",
+                'isSymbolicLink',
                 stat.isSymbolicLink());
       if (e.code == 'EACCES') {
         // The binary may not be executable by this user...
@@ -250,7 +250,7 @@ export async function scanDirForCompilerKits(dir: string, pr?: ProgressReporter)
       } else if (e.code == 'ENOENT') {
         // This will happen on Windows if we try to "execute" a directory
         return null;
-      } else if (e.code == "UNKNOWN" && process.platform == "win32") {
+      } else if (e.code == 'UNKNOWN' && process.platform == 'win32') {
         // This is when file is not executable (in windows)
         return null;
       }
@@ -285,7 +285,7 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const installs = [] as VSInstallation[];
   const inst_ids = [] as string[];
   const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
-  const vswhere_args = [ '-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease' ];
+  const vswhere_args = ['-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease'];
   const vswhere_res = await proc.execute(vswhere_exe, vswhere_args).result;
   if (vswhere_res.retc !== 0) {
     log.error('Failed to execute vswhere.exe:', vswhere_res.stdout);
@@ -338,7 +338,7 @@ const MSVC_ENVIRONMENT_VARIABLES = [
 async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<string, string>|undefined> {
   const bat = [
     `@echo off`,
-    `call "${devbat}" ${args.join(" ")} || exit`,
+    `call "${devbat}" ${args.join(' ')} || exit`,
   ];
   for (const envvar of MSVC_ENVIRONMENT_VARIABLES) {
     bat.push(`echo ${envvar} := %${envvar}%`);
@@ -346,14 +346,14 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
   const fname = Math.random().toString() + '.bat';
   const batpath = path.join(paths.tmpDir, `vs-cmt-${fname}`);
   await fs.writeFile(batpath, bat.join('\r\n'));
-  const res = await proc.execute(batpath, [], null, {shell : true}).result;
+  const res = await proc.execute(batpath, [], null, {shell: true}).result;
   await fs.unlink(batpath);
   const output = res.stdout;
   if (res.retc !== 0) {
     console.log(`Error running ${devbat}`, output);
     return;
   }
-  if (output.includes("Invalid host architecture") || output.includes("Error in script usage")) {
+  if (output.includes('Invalid host architecture') || output.includes('Error in script usage')) {
     return;
   }
   if (!output) {
@@ -377,25 +377,25 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
  * Platform arguments for VS Generators
  */
 const VsArchitectures: {[key: string]: string} = {
-  'amd64' : 'x64',
-  'arm' : 'ARM',
-  'amd64_arm' : 'ARM',
+  'amd64': 'x64',
+  'arm': 'ARM',
+  'amd64_arm': 'ARM',
 };
 
 /**
  * Preferred CMake VS generators by VS version
  */
 const VsGenerators: {[key: string]: string} = {
-  '14' : 'Visual Studio 14 2015',
-  '15' : 'Visual Studio 15 2017',
-  'VS120COMNTOOLS' : 'Visual Studio 12 2013',
-  'VS140COMNTOOLS' : 'Visual Studio 14 2015',
+  '14': 'Visual Studio 14 2015',
+  '15': 'Visual Studio 15 2017',
+  'VS120COMNTOOLS': 'Visual Studio 12 2013',
+  'VS140COMNTOOLS': 'Visual Studio 14 2015',
 };
 
 async function varsForVSInstallation(inst: VSInstallation, arch: string): Promise<Map<string, string>|null> {
   const common_dir = path.join(inst.installationPath, 'Common7', 'Tools');
   const devbat = path.join(common_dir, 'VsDevCmd.bat');
-  const variables = await collectDevBatVars(devbat, [ '-no_logo', `-arch=${arch}` ]);
+  const variables = await collectDevBatVars(devbat, ['-no_logo', `-arch=${arch}`]);
   if (!variables) {
     return null;
   } else {
@@ -414,17 +414,17 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
   const name = installName + ' - ' + arch;
   log.debug('Checking for kit: ' + name);
   if (pr) {
-    pr.report({message : `Checking ${installName} with ${arch}`});
+    pr.report({message: `Checking ${installName} with ${arch}`});
   }
   const variables = await varsForVSInstallation(inst, arch);
   if (!variables)
     return null;
 
   const kit: VSKit = {
-    type : 'vsKit',
-    name : name,
-    visualStudio : inst.instanceId,
-    visualStudioArchitecture : arch,
+    type: 'vsKit',
+    name: name,
+    visualStudio: inst.instanceId,
+    visualStudioArchitecture: arch,
   };
 
   const version = /^(\d+)+./.exec(inst.installationVersion);
@@ -432,8 +432,8 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
     const generatorName: string|undefined = VsGenerators[version[1]];
     if (generatorName) {
       kit.preferredGenerator = {
-        name : generatorName,
-        platform : VsArchitectures[arch] as string || undefined,
+        name: generatorName,
+        platform: VsArchitectures[arch] as string || undefined,
       };
     }
   }
@@ -448,7 +448,7 @@ export async function scanForVSKits(pr?: ProgressReporter): Promise<VSKit[]> {
   const installs = await vsInstallations();
   const prs = installs.map(async(inst): Promise<VSKit[]> => {
     const ret = [] as VSKit[];
-    const arches = [ 'x86', 'amd64', 'x86_amd64', 'x86_arm', 'amd64_arm', 'amd64_x86' ];
+    const arches = ['x86', 'amd64', 'x86_amd64', 'x86_arm', 'amd64_arm', 'amd64_x86'];
     const sub_prs = arches.map(arch => tryCreateNewVCEnvironment(inst, arch, pr));
     const maybe_kits = await Promise.all(sub_prs);
     maybe_kits.map(k => k ? ret.push(k) : null);
@@ -473,10 +473,10 @@ export async function getVSKitEnvironment(kit: VSKit): Promise<Map<string, strin
  */
 export async function scanForKits() {
   log.debug('Scanning for Kits on system');
-  return vscode.window.withProgress({location : vscode.ProgressLocation.Window, title : 'Scanning for kits'},
+  return vscode.window.withProgress({location: vscode.ProgressLocation.Window, title: 'Scanning for kits'},
                                     async pr => {
                                       const isWin32 = process.platform === 'win32';
-                                      pr.report({message : 'Scanning for CMake kits...'});
+                                      pr.report({message: 'Scanning for CMake kits...'});
                                       // Search directories on `PATH` for compiler binaries
                                       const pathvar = process.env['PATH']!;
                                       const sep = isWin32 ? ';' : ':';
@@ -619,13 +619,13 @@ export class KitManager implements vscode.Disposable {
     log.debug('Opening kit selection QuickPick');
     const items = this._kits.map((kit): KitItem => {
       return {
-        label : kit.name,
-        description : descriptionForKit(kit),
-        kit : kit,
+        label: kit.name,
+        description: descriptionForKit(kit),
+        kit: kit,
       };
     });
     const chosen = await vscode.window.showQuickPick(items, {
-      placeHolder : 'Select a Kit',
+      placeHolder: 'Select a Kit',
     });
     if (chosen === undefined) {
       log.debug('User cancelled Kit selection');
@@ -723,30 +723,30 @@ export class KitManager implements vscode.Disposable {
       if ('compilers' in item_) {
         const item = item_ as CompilerKit;
         return {
-          type : 'compilerKit',
-          name : item.name,
-          compilers : item.compilers,
-          preferredGenerator : item.preferredGenerator,
-          cmakeSettings : item.cmakeSettings,
+          type: 'compilerKit',
+          name: item.name,
+          compilers: item.compilers,
+          preferredGenerator: item.preferredGenerator,
+          cmakeSettings: item.cmakeSettings,
         };
       } else if ('toolchainFile' in item_) {
         const item = item_ as ToolchainKit;
         return {
-          type : 'toolchainKit',
-          name : item.name,
-          toolchainFile : item.toolchainFile,
-          preferredGenerator : item.preferredGenerator,
-          cmakeSettings : item.cmakeSettings,
+          type: 'toolchainKit',
+          name: item.name,
+          toolchainFile: item.toolchainFile,
+          preferredGenerator: item.preferredGenerator,
+          cmakeSettings: item.cmakeSettings,
         };
       } else if ('visualStudio' in item_) {
         const item = item_ as VSKit;
         return {
-          type : 'vsKit',
-          name : item.name,
-          visualStudio : item.visualStudio,
-          visualStudioArchitecture : item.visualStudioArchitecture,
-          preferredGenerator : item.preferredGenerator,
-          cmakeSettings : item.cmakeSettings,
+          type: 'vsKit',
+          name: item.name,
+          visualStudio: item.visualStudio,
+          visualStudioArchitecture: item.visualStudioArchitecture,
+          preferredGenerator: item.preferredGenerator,
+          cmakeSettings: item.cmakeSettings,
         };
       } else {
         vscode.window.showErrorMessage('Your cmake-kits.json file contains one or more invalid entries.');
@@ -777,8 +777,8 @@ export class KitManager implements vscode.Disposable {
       const item = await vscode.window.showInformationMessage<DoOpen>(
           'CMake Tools has scanned for available kits and saved them to a file. Would you like to edit the Kits file?',
           {},
-          {title : "Yes", doOpen : true},
-          {title : "No", isCloseAffordance : true, doOpen : false});
+          {title: 'Yes', doOpen: true},
+          {title: 'No', isCloseAffordance: true, doOpen: false});
       if (item === undefined) {
         return;
       }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -140,8 +140,8 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
         type: 'compilerKit',
         name,
         compilers: {
-          'CXX': gxx_bin,
-          'C': bin,
+          CXX: gxx_bin,
+          C: bin,
         }
       };
     } else {
@@ -149,7 +149,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
         type: 'compilerKit',
         name,
         compilers: {
-          'C': bin,
+          C: bin,
         }
       };
     }
@@ -177,8 +177,8 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
         type: 'compilerKit',
         name,
         compilers: {
-          'C': bin,
-          'CXX': clangxx_bin,
+          C: bin,
+          CXX: clangxx_bin,
         },
       };
     } else {
@@ -186,7 +186,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
         type: 'compilerKit',
         name,
         compilers: {
-          'C': bin,
+          C: bin,
         },
       };
     }
@@ -377,19 +377,19 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
  * Platform arguments for VS Generators
  */
 const VsArchitectures: {[key: string]: string} = {
-  'amd64': 'x64',
-  'arm': 'ARM',
-  'amd64_arm': 'ARM',
+  amd64: 'x64',
+  arm: 'ARM',
+  amd64_arm: 'ARM',
 };
 
 /**
  * Preferred CMake VS generators by VS version
  */
 const VsGenerators: {[key: string]: string} = {
-  '14': 'Visual Studio 14 2015',
-  '15': 'Visual Studio 15 2017',
-  'VS120COMNTOOLS': 'Visual Studio 12 2013',
-  'VS140COMNTOOLS': 'Visual Studio 14 2015',
+  14: 'Visual Studio 14 2015',
+  15: 'Visual Studio 15 2017',
+  VS120COMNTOOLS: 'Visual Studio 12 2013',
+  VS140COMNTOOLS: 'Visual Studio 14 2015',
 };
 
 async function varsForVSInstallation(inst: VSInstallation, arch: string): Promise<Map<string, string>|null> {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -138,7 +138,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
     if (await fs.exists(gxx_bin)) {
       return {
         type: 'compilerKit',
-        name: name,
+        name,
         compilers: {
           'CXX': gxx_bin,
           'C': bin,
@@ -147,7 +147,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
     } else {
       return {
         type: 'compilerKit',
-        name: name,
+        name,
         compilers: {
           'C': bin,
         }
@@ -175,7 +175,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
     if (await fs.exists(clangxx_bin)) {
       return {
         type: 'compilerKit',
-        name: name,
+        name,
         compilers: {
           'C': bin,
           'CXX': clangxx_bin,
@@ -184,7 +184,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
     } else {
       return {
         type: 'compilerKit',
-        name: name,
+        name,
         compilers: {
           'C': bin,
         },
@@ -422,7 +422,7 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
 
   const kit: VSKit = {
     type: 'vsKit',
-    name: name,
+    name,
     visualStudio: inst.instanceId,
     visualStudioArchitecture: arch,
   };
@@ -621,7 +621,7 @@ export class KitManager implements vscode.Disposable {
       return {
         label: kit.name,
         description: descriptionForKit(kit),
-        kit: kit,
+        kit,
       };
     });
     const chosen = await vscode.window.showQuickPick(items, {

--- a/src/legacy-driver.ts
+++ b/src/legacy-driver.ts
@@ -7,10 +7,10 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import * as api from './api';
-import {CMakeCache} from "./cache";
+import {CMakeCache} from './cache';
 import {CompilationDatabase} from './compdb';
 import {CMakeDriver} from './driver';
-import {Kit} from "./kit";
+import {Kit} from './kit';
 // import * as proc from './proc';
 import * as logging from './logging';
 import paths from './paths';

--- a/src/legacy-driver.ts
+++ b/src/legacy-driver.ts
@@ -9,11 +9,11 @@ import * as vscode from 'vscode';
 import * as api from './api';
 import {CMakeCache} from "./cache";
 import {CompilationDatabase} from './compdb';
-import paths from './paths';
 import {CMakeDriver} from './driver';
 import {Kit} from "./kit";
 // import * as proc from './proc';
 import * as logging from './logging';
+import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
 import rollbar from './rollbar';
@@ -111,7 +111,7 @@ export class LegacyCMakeDriver extends CMakeDriver {
   /**
    * Watcher for the CMake cache file on disk.
    */
-  private _cacheWatcher = vscode.workspace.createFileSystemWatcher(this.cachePath);
+  private readonly _cacheWatcher = vscode.workspace.createFileSystemWatcher(this.cachePath);
 
   get cmakeCache() { return this._cmakeCache; }
   private _cmakeCache: CMakeCache|null = null;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -119,9 +119,9 @@ async function _openLogFile() {
       const logfilepath = path.join(paths.dataDir, 'log.txt');
       await fs.mkdir_p(path.dirname(logfilepath));
       if (await fs.exists(logfilepath)) {
-        return node_fs.createWriteStream(logfilepath, {flags : 'r+'});
+        return node_fs.createWriteStream(logfilepath, {flags: 'r+'});
       } else {
-        return node_fs.createWriteStream(logfilepath, {flags : 'w'});
+        return node_fs.createWriteStream(logfilepath, {flags: 'w'});
       }
     })();
   }
@@ -150,17 +150,17 @@ class SingletonLogger {
     case LogLevel.Note:
       if (process.env['CMT_QUIET_CONSOLE'] !== '1') {
         // tslint:disable-next-line
-        console.info("[CMakeTools]", raw_message);
+        console.info('[CMakeTools]', raw_message);
       }
       break;
     case LogLevel.Warning:
       // tslint:disable-next-line
-      console.warn("[CMakeTools]", raw_message);
+      console.warn('[CMakeTools]', raw_message);
       break;
     case LogLevel.Error:
     case LogLevel.Fatal:
       // tslint:disable-next-line
-      console.error("[CMakeTools]", raw_message);
+      console.error('[CMakeTools]', raw_message);
       break;
     }
     // Write to the logfile asynchronously.

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -65,6 +65,7 @@ function levelEnabled(level: LogLevel): boolean {
   case 'fatal':
     return level >= LogLevel.Fatal;
   default:
+    // tslint:disable-next-line
     console.error('Invalid logging level in settings.json');
     return true;
   }
@@ -148,20 +149,25 @@ class SingletonLogger {
     case LogLevel.Info:
     case LogLevel.Note:
       if (process.env['CMT_QUIET_CONSOLE'] !== '1') {
+        // tslint:disable-next-line
         console.info("[CMakeTools]", raw_message);
       }
       break;
     case LogLevel.Warning:
+      // tslint:disable-next-line
       console.warn("[CMakeTools]", raw_message);
       break;
     case LogLevel.Error:
     case LogLevel.Fatal:
+      // tslint:disable-next-line
       console.error("[CMakeTools]", raw_message);
       break;
     }
     // Write to the logfile asynchronously.
-    this._logStream.then(strm => strm.write(raw_message + '\n'))
-        .catch(e => { console.error('Unhandled error while writing CMakeTools log file', e); });
+    this._logStream.then(strm => strm.write(raw_message + '\n')).catch(e => {
+      // tslint:disable-next-line
+      console.error('Unhandled error while writing CMakeTools log file', e);
+    });
     // Write to our output channel
     if (levelEnabled(level)) {
       this._channel.appendLine(user_message);

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -142,7 +142,7 @@ class SingletonLogger {
     }
     const user_message = args.map(a => a.toString()).join(' ');
     const prefix = new Date().toISOString() + ` [${levelName(level)}]`;
-    const raw_message = prefix + ' ' + user_message;
+    const raw_message = `${prefix} ${user_message}`;
     switch (level) {
     case LogLevel.Trace:
     case LogLevel.Debug:

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -81,7 +81,7 @@ class OutputChannelManager implements vscode.Disposable {
   /**
    * Channels that this manager knows about
    */
-  private _channels = new Map<string, vscode.OutputChannel>();
+  private readonly _channels = new Map<string, vscode.OutputChannel>();
 
   /**
    * Get the single instance of a channel with the given name. If the channel
@@ -132,7 +132,7 @@ async function _openLogFile() {
  * Manages and controls logging
  */
 class SingletonLogger {
-  private _logStream = _openLogFile();
+  private readonly _logStream = _openLogFile();
 
   private get _channel() { return channelManager.get('CMake/Build'); }
 

--- a/src/nag.ts
+++ b/src/nag.ts
@@ -9,6 +9,8 @@ import * as https from 'https';
 import * as yaml from 'js-yaml';
 import * as vscode from 'vscode';
 
+// tslint:disable:no-console
+
 const open = require('open') as ((url: string, appName?: string, callback?: Function) => void);
 
 const NAG_REMOTE_URL = 'https://vector-of-bool.github.io/vscode-cmt-nags.yaml';

--- a/src/nag.ts
+++ b/src/nag.ts
@@ -214,4 +214,4 @@ export class NagManager {
       this._pollRemoteForNags();
     } catch (e) { console.error('Error starting up initial event polling.', e); }
   }
-};
+}

--- a/src/nag.ts
+++ b/src/nag.ts
@@ -122,14 +122,14 @@ function getOrInitNagState(ext: vscode.ExtensionContext): NagState {
 
 export class NagManager {
   get onNag() { return this._nagEmitter.event; }
-  private _nagEmitter = new vscode.EventEmitter<Nag>();
-  private _nagState = getOrInitNagState(this.extensionContext);
+  private readonly _nagEmitter = new vscode.EventEmitter<Nag>();
+  private readonly _nagState = getOrInitNagState(this.extensionContext);
   private _writeNagState() { writeNagState(this.extensionContext, this._nagState); }
 
   constructor(readonly extensionContext: vscode.ExtensionContext) {}
 
   private _pollRemoteForNags() {
-    const req = https.get(NAG_REMOTE_URL, (res) => {
+    const req = https.get(NAG_REMOTE_URL, res => {
       if (res.statusCode !== 200) {
         // Stop trying.
         console.error('Not polling for CMake-Tools updates.');
@@ -153,7 +153,7 @@ export class NagManager {
             });
       });
     });
-    req.on('error', (err) => {
+    req.on('error', err => {
       console.error('Error polling remote for nags', err);
       setTimeout(() => {
         // Poll again in ten minutes

--- a/src/nag.ts
+++ b/src/nag.ts
@@ -29,36 +29,36 @@ export interface Nag {
 }
 
 export function parseNagData(items: any): Nag[]|null {
-  const validator = new ajv({allErrors : true, format : 'full'}).compile({
-    type : 'object',
-    properties : {
-      nags : {
-        type : 'array',
-        items : {
-          type : 'object',
-          properties : {
-            message : {type : 'string'},
-            id : {type : 'string'},
-            resetSeconds : {type : 'number'},
-            items : {
-              type : 'array',
-              items : {
-                type : 'object',
-                properties : {
-                  title : {type : 'string'},
-                  isCloseAffordance : {type : 'boolean'},
-                  openLink : {type : 'string'},
-                  askLater : {type : 'boolean'},
-                  neverAgain : {type : 'boolean'},
+  const validator = new ajv({allErrors: true, format: 'full'}).compile({
+    type: 'object',
+    properties: {
+      nags: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            message: {type: 'string'},
+            id: {type: 'string'},
+            resetSeconds: {type: 'number'},
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  title: {type: 'string'},
+                  isCloseAffordance: {type: 'boolean'},
+                  openLink: {type: 'string'},
+                  askLater: {type: 'boolean'},
+                  neverAgain: {type: 'boolean'},
                 },
-                required : [
+                required: [
                   'title',
                   'isCloseAffordance',
                 ],
               },
             },
           },
-          required : [
+          required: [
             'message',
             'items',
             'id',
@@ -67,7 +67,7 @@ export function parseNagData(items: any): Nag[]|null {
         },
       },
     },
-    required : [
+    required: [
       'nags',
     ],
   });
@@ -97,7 +97,7 @@ export function parseNagYAML(str: string): Nag[]|null {
 interface NagState {
   nagsByID: {
     [id: string]: undefined|{
-      nextShowTimeMS : number,
+      nextShowTimeMS: number,
       neverAgain: boolean,
     };
   };
@@ -112,7 +112,7 @@ function getOrInitNagState(ext: vscode.ExtensionContext): NagState {
     return state;
   }
   const init_state: NagState = {
-    nagsByID : {
+    nagsByID: {
 
     }
   };
@@ -190,14 +190,14 @@ export class NagManager {
       if (chosen.askLater) {
         // We'll ask again when the reset timer is met
         state.nagsByID[nag.id] = {
-          neverAgain : false,
-          nextShowTimeMS : next_time_ms,
+          neverAgain: false,
+          nextShowTimeMS: next_time_ms,
         };
       } else if (chosen.neverAgain) {
         // User doesn't want to be bothered again
         state.nagsByID[nag.id] = {
-          neverAgain : true,  // Prevents this nag from ever reappearing
-          nextShowTimeMS : next_time_ms,
+          neverAgain: true,  // Prevents this nag from ever reappearing
+          nextShowTimeMS: next_time_ms,
         };
       }
       if (chosen.openLink) {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -25,7 +25,7 @@ class Paths {
     if (process.platform == 'win32') {
       return process.env['AppData']!;
     } else {
-      const xdg_dir = process.env["XDG_DATA_HOME"];
+      const xdg_dir = process.env['XDG_DATA_HOME'];
       if (xdg_dir) {
         return xdg_dir;
       }
@@ -57,7 +57,7 @@ class Paths {
         if (err) {
           resolve(null);
         } else {
-          console.assert(resolved, "`which` didn't do what it should have.");
+          console.assert(resolved, '`which` didn\'t do what it should have.');
           resolve(resolved!);
         }
       });

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -65,9 +65,7 @@ class Paths {
   }
 
   get cmakePath(): Promise<string> { return this._getCMakePath(); }
-  get ctestPath(): Promise<string> {
-    return this._getCTestPath();
-  }
+  get ctestPath(): Promise<string> { return this._getCTestPath(); }
 
   private async _getCTestPath(): Promise<string> {
     const ctest_path = config.raw_ctestPath;

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -22,7 +22,7 @@ import * as rimraf from 'rimraf';
 export namespace fs {
 
 export function exists(fspath: string): Promise<boolean> {
-  return new Promise<boolean>((resolve, _reject) => { fs_.exists(fspath, res => resolve(res)); })
+  return new Promise<boolean>((resolve, _reject) => { fs_.exists(fspath, res => resolve(res)); });
 }
 
 export const readFile = promisify(fs_.readFile);

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -80,7 +80,7 @@ export function copyFile(inpath: string, outpath: string): Promise<void> {
     reader.on('open', _fd => {
       const writer = fs_.createWriteStream(outpath);
       writer.on('error', e => reject(e));
-      writer.on('open', _fd => { reader.pipe(writer); });
+      writer.on('open', _fd2 => { reader.pipe(writer); });
       writer.on('close', () => resolve());
     });
   });

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -56,14 +56,14 @@ export async function mkdir_p(fspath: string): Promise<void> {
     await mkdir_p(parent);
   } else {
     if (!(await stat(parent)).isDirectory()) {
-      throw new Error("Cannot create ${fspath}: ${parent} is a non-directory");
+      throw new Error('Cannot create ${fspath}: ${parent} is a non-directory');
     }
   }
   if (!await exists(fspath)) {
     await mkdir(fspath);
   } else {
     if (!(await stat(fspath)).isDirectory()) {
-      throw new Error("Cannot mkdir_p on ${fspath}. It exists, and is not a directory!");
+      throw new Error('Cannot mkdir_p on ${fspath}. It exists, and is not a directory!');
     }
   }
 }

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -110,9 +110,9 @@ export function execute(command: string,
   if (options && options.cwd) {
     spawn_opts.cwd = options.cwd;
   }
-  let child: proc.ChildProcess = proc.spawn(command, args, spawn_opts);
+  const child: proc.ChildProcess = proc.spawn(command, args, spawn_opts);
   const result = new Promise<ExecutionResult>((resolve, reject) => {
-    child.on('error', (err) => { reject(err); });
+    child.on('error', err => { reject(err); });
     let stdout_acc = '';
     let line_acc = '';
     let stderr_acc = '';
@@ -151,7 +151,7 @@ export function execute(command: string,
     });
     // Don't stop until the child stream is closed, otherwise we might not read
     // the whole output of the command.
-    child.on('close', (retc) => {
+    child.on('close', retc => {
       if (line_acc && outputConsumer) {
         outputConsumer.output(line_acc);
       }

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -158,7 +158,7 @@ export function execute(command: string,
       if (stderr_line_acc && outputConsumer) {
         outputConsumer.error(stderr_line_acc);
       }
-      resolve({retc: retc, stdout: stdout_acc, stderr: stderr_acc});
+      resolve({retc, stdout: stdout_acc, stderr: stderr_acc});
     });
   });
   return {child, result};

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -93,7 +93,7 @@ export function execute(command: string,
              // We do simple quoting of arguments with spaces.
              // This is only shown to the user,
              // and doesn't have to be 100% correct.
-             + [ command ]
+             + [command]
                    .concat(args)
                    .map(a => a.replace('"', '\"'))
                    .map(a => /[ \n\r\f;\t]/.test(a) ? `"${a}"` : a)
@@ -104,8 +104,8 @@ export function execute(command: string,
   }
   const final_env = util.mergeEnvironment(process.env as EnvironmentVariables, options.environment || {});
   const spawn_opts: proc.SpawnOptions = {
-    env : final_env,
-    shell : !!options.shell,
+    env: final_env,
+    shell: !!options.shell,
   };
   if (options && options.cwd) {
     spawn_opts.cwd = options.cwd;
@@ -158,7 +158,7 @@ export function execute(command: string,
       if (stderr_line_acc && outputConsumer) {
         outputConsumer.error(stderr_line_acc);
       }
-      resolve({retc : retc, stdout : stdout_acc, stderr : stderr_acc});
+      resolve({retc: retc, stdout: stdout_acc, stderr: stderr_acc});
     });
   });
   return {child, result};

--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -109,7 +109,7 @@ class RollbarController {
     debugger;
     if (this._enabled) {
       const stack = new Error().stack;
-      return this._rollbar.error(what, additional, {stack: stack});
+      return this._rollbar.error(what, additional, {stack});
     }
     return null;
   }

--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -21,7 +21,7 @@ class RollbarController {
   /**
    * The Rollbar client instance we use to communicate.
    */
-  private _rollbar = new Rollbar({
+  private readonly _rollbar = new Rollbar({
     accessToken : '14d411d713be4a5a9f9d57660534cac7',
     reportLevel: 'error',
     payload: this._payload,

--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -16,13 +16,13 @@ class RollbarController {
   /**
    * The payload to send with any messages. Can be updated via `updatePayload`.
    */
-  private readonly _payload: object = {platform : 'client'};
+  private readonly _payload: object = {platform: 'client'};
 
   /**
    * The Rollbar client instance we use to communicate.
    */
   private readonly _rollbar = new Rollbar({
-    accessToken : '14d411d713be4a5a9f9d57660534cac7',
+    accessToken: '14d411d713be4a5a9f9d57660534cac7',
     reportLevel: 'error',
     payload: this._payload,
   });
@@ -59,14 +59,14 @@ class RollbarController {
       log.debug('Asking user for permission to user Rollbar...');
       // We haven't asked yet. Ask them now:
       const item = await vscode.window.showInformationMessage(
-          "Would you like to opt-in to send anonymous error and exception data to help improve CMake Tools?",
+          'Would you like to opt-in to send anonymous error and exception data to help improve CMake Tools?',
           {
-            title : 'Yes!',
-            isCloseAffordance : false,
+            title: 'Yes!',
+            isCloseAffordance: false,
           } as vscode.MessageItem,
           {
-            title : 'No Thanks',
-            isCloseAffordance : true,
+            title: 'No Thanks',
+            isCloseAffordance: true,
           } as vscode.MessageItem);
 
       if (item === undefined) {
@@ -109,7 +109,7 @@ class RollbarController {
     debugger;
     if (this._enabled) {
       const stack = new Error().stack;
-      return this._rollbar.error(what, additional, {stack : stack});
+      return this._rollbar.error(what, additional, {stack: stack});
     }
     return null;
   }
@@ -121,7 +121,7 @@ class RollbarController {
    */
   updatePayload(data: object) {
     Object.assign(this._payload, data);
-    this._rollbar.configure({payload : this._payload});
+    this._rollbar.configure({payload: this._payload});
     log.debug('Updated Rollbar payload', JSON.stringify(data));
   }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,11 +1,11 @@
 import * as ajv from 'ajv';
 import * as path from 'path';
 
-import {fs} from "./pr";
-import {thisExtensionPath} from "./util";
+import {fs} from './pr';
+import {thisExtensionPath} from './util';
 
 export async function loadSchema(filepath: string): Promise<ajv.ValidateFunction> {
   const schema_path = path.isAbsolute(filepath) ? filepath : path.join(thisExtensionPath(), filepath);
   const schema_data = JSON.parse((await fs.readFile(schema_path)).toString());
-  return new ajv({allErrors : true, format : 'full'}).compile(schema_data);
+  return new ajv({allErrors: true, format: 'full'}).compile(schema_data);
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -41,7 +41,7 @@ export class StateManager {
    * The keyword settings for the build variant
    */
   get activeVariantSettings(): Map<string, string>|null {
-    const pairs = this.extensionContext.workspaceState.get<[ string, string ][]>('activeVariantSettings');
+    const pairs = this.extensionContext.workspaceState.get<[string, string][]>('activeVariantSettings');
     if (pairs) {
       return new Map<string, string>(pairs);
     } else {
@@ -50,7 +50,7 @@ export class StateManager {
   }
   set activeVariantSettings(settings: Map<string, string>|null) {
     if (settings) {
-      const pairs: [ string, string ][] = Array.from(settings.entries());
+      const pairs: [string, string][] = Array.from(settings.entries());
       this.extensionContext.workspaceState.update('activeVariantSettings', pairs);
     } else {
       this.extensionContext.workspaceState.update('activeVariantSettings', null);

--- a/src/status.ts
+++ b/src/status.ts
@@ -168,7 +168,7 @@ export class StatusBar implements vscode.Disposable {
     const total = v.total;
     const good = passing == total;
     const icon = good ? 'check' : 'x';
-    this._testButton.text = `$(${icon}) ${passing}/${total} ` + (total == 1 ? 'test' : 'tests') + ' passing';
+    this._testButton.text = `$(${icon}) ${passing}/${total} ${total == 1 ? 'test' : 'tests'} passing`;
     this._testButton.color = good ? 'lightgreen' : 'yellow';
   }
 

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import {BasicTestResults} from "./ctest";
+import {BasicTestResults} from './ctest';
 
 interface Hideable {
   show(): void;

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,7 +29,7 @@ export function replaceAll(str: string, needle: string, what: string) {
  * @returns The modified string
  */
 export function removeAllPatterns(str: string, patterns: string[]): string {
-  return patterns.reduce((acc, needle) => { return replaceAll(acc, needle, ''); }, str);
+  return patterns.reduce((acc, needle) => replaceAll(acc, needle, ''), str);
 }
 
 /**
@@ -141,7 +141,7 @@ export function cmakeify(value: (string|boolean|number|string[])): CMakeValue {
   } else if (typeof (value) === 'string') {
     ret.type = 'STRING';
     ret.value = replaceAll(value, ';', '\\;');
-  } else if (value instanceof Number || typeof value === 'number') {
+  } else if (typeof value === 'number') {
     ret.type = 'STRING';
     ret.value = value.toString();
   } else if (value instanceof Array) {
@@ -259,9 +259,9 @@ export function mergeEnvironment(...env: EnvironmentVariables[]) {
         acc2[key.toUpperCase()] = vars[key];
         return acc2;
       }, {});
-      return Object.assign({}, acc, norm_vars);
+      return {...acc, ...norm_vars};
     } else {
-      return Object.assign({}, acc, vars);
+      return {...acc, ...vars};
     }
   }, {})
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -63,7 +63,7 @@ export function normalizePath(p: string, normalize_case = true): string {
  */
 export function isTruthy(value: (boolean|string|null|undefined|number)) {
   if (typeof value === 'string') {
-    return !([ '', 'FALSE', 'OFF', '0', 'NOTFOUND', 'NO', 'N', 'IGNORE' ].indexOf(value) >= 0
+    return !(['', 'FALSE', 'OFF', '0', 'NOTFOUND', 'NO', 'N', 'IGNORE'].indexOf(value) >= 0
              || value.endsWith('-NOTFOUND'));
   }
   // Numbers/bools/etc. follow common C-style truthiness
@@ -75,8 +75,8 @@ export function isTruthy(value: (boolean|string|null|undefined|number)) {
  * `getOwnPropertyNames`
  * @param obj The object to iterate
  */
-export function objectPairs<V>(obj: {[key: string]: V}): [ string, V ][] {
-  return Object.getOwnPropertyNames(obj).map(key => ([ key, obj[key] ] as [string, V]));
+export function objectPairs<V>(obj: {[key: string]: V}): [string, V][] {
+  return Object.getOwnPropertyNames(obj).map(key => ([key, obj[key]] as [string, V]));
 }
 
 /**
@@ -132,8 +132,8 @@ export interface CMakeValue {
 
 export function cmakeify(value: (string|boolean|number|string[])): CMakeValue {
   const ret: CMakeValue = {
-    type : 'UNKNOWN',
-    value : '',
+    type: 'UNKNOWN',
+    value: '',
   };
   if (value === true || value === false) {
     ret.type = 'BOOL';
@@ -166,7 +166,7 @@ export async function termProc(child: child_process.ChildProcess) {
 async function _killTree(pid: number) {
   if (process.platform !== 'win32') {
     let children: number[] = [];
-    const stdout = (await execute('pgrep', [ '-P', pid.toString() ], null, {silent : true}).result).stdout.trim();
+    const stdout = (await execute('pgrep', ['-P', pid.toString()], null, {silent: true}).result).stdout.trim();
     if (!!stdout.length) {
       children = stdout.split('\n').map(line => Number.parseInt(line));
     }
@@ -217,9 +217,9 @@ export function parseVersion(str: string): Version {
   }
   const [, major, minor, patch] = mat;
   return {
-    major : parseInt(major),
-    minor : parseInt(minor),
-    patch : parseInt(patch),
+    major: parseInt(major),
+    minor: parseInt(minor),
+    patch: parseInt(patch),
   };
 }
 
@@ -266,12 +266,12 @@ export function mergeEnvironment(...env: EnvironmentVariables[]) {
   }, {});
 }
 
-export function parseCompileDefinition(str: string): [ string, string|null ] {
+export function parseCompileDefinition(str: string): [string, string|null] {
   if (/^\w+$/.test(str)) {
-    return [ str, null ];
+    return [str, null];
   } else {
     const key = str.split('=', 1)[0];
-    return [ key, str.substr(key.length + 1) ];
+    return [key, str.substr(key.length + 1)];
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -183,10 +183,11 @@ async function _killTree(pid: number) {
         throw e;
       }
     }
-  } else {  // Because reasons, Node's proc.kill doesn't work on killing child
+  } else {
+    // Because reasons, Node's proc.kill doesn't work on killing child
     // processes transitively. We have to do a sad and manually kill the
     // task using taskkill.
-    child_process.exec('taskkill /pid ' + pid.toString() + ' /T /F');
+    child_process.exec(`taskkill /pid ${pid.toString()} /T /F`);
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -148,7 +148,7 @@ export function cmakeify(value: (string|boolean|number|string[])): CMakeValue {
     ret.type = 'STRING';
     ret.value = value.join(';');
   } else {
-    throw new Error(`Invalid value to convert to cmake value: ${value}`)
+    throw new Error(`Invalid value to convert to cmake value: ${value}`);
   }
   return ret;
 }
@@ -263,7 +263,7 @@ export function mergeEnvironment(...env: EnvironmentVariables[]) {
     } else {
       return {...acc, ...vars};
     }
-  }, {})
+  }, {});
 }
 
 export function parseCompileDefinition(str: string): [ string, string|null ] {

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -5,9 +5,9 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import * as logging from './logging';
-import {fs} from "./pr";
+import {fs} from './pr';
 import rollbar from './rollbar';
-import {loadSchema} from "./schema";
+import {loadSchema} from './schema';
 import {StateManager} from './state';
 import * as util from './util';
 import {MultiWatcher} from './watcher';
@@ -42,33 +42,33 @@ export interface VariantCombination extends vscode.QuickPickItem {
 }
 
 export interface VariantFileContent {
-  [key: string]: {default: string; description : string; choices : {[name: string] : VariantConfigurationOptions;};};
+  [key: string]: {default: string; description: string; choices: {[name: string]: VariantConfigurationOptions;};};
 }
 
 export const DEFAULT_VARIANTS: VariantFileContent = {
-  buildType : {
-    default : 'debug',
-    description : 'The build type',
-    choices : {
-      debug : {
-        short : 'Debug',
-        long : 'Emit debug information without performing optimizations',
-        buildType : 'Debug',
+  buildType: {
+    default: 'debug',
+    description: 'The build type',
+    choices: {
+      debug: {
+        short: 'Debug',
+        long: 'Emit debug information without performing optimizations',
+        buildType: 'Debug',
       },
-      release : {
-        short : 'Release',
-        long : 'Enable optimizations, omit debug info',
-        buildType : 'Release',
+      release: {
+        short: 'Release',
+        long: 'Enable optimizations, omit debug info',
+        buildType: 'Release',
       },
-      minsize : {
-        short : 'MinSizeRel',
-        long : 'Optimize for smallest binary size',
-        buildType : 'MinSizeRel',
+      minsize: {
+        short: 'MinSizeRel',
+        long: 'Optimize for smallest binary size',
+        buildType: 'MinSizeRel',
       },
-      reldeb : {
-        short : 'RelWithDebInfo',
-        long : 'Perform optimizations AND include debugging information',
-        buildType : 'RelWithDebInfo',
+      reldeb: {
+        short: 'RelWithDebInfo',
+        long: 'Perform optimizations AND include debugging information',
+        buildType: 'RelWithDebInfo',
       }
     }
   }
@@ -186,16 +186,16 @@ export class VariantManager implements vscode.Disposable {
       }
 
       sets.set(setting_name, {
-        default_ : def,
-        description : desc,
-        choices : choices,
+        default_: def,
+        description: desc,
+        choices: choices,
       });
     }
 
     if (loaded_default) {
-      log.info("Loaded default variants");
+      log.info('Loaded default variants');
     } else {
-      log.info("Loaded new set of variants");
+      log.info('Loaded new set of variants');
     }
 
 
@@ -207,8 +207,8 @@ export class VariantManager implements vscode.Disposable {
   variantConfigurationOptionsForKWs(keywordSetting: Map<string, string>): VariantConfigurationOptions[]|string {
     const vars = this._variants;
     let error: string|undefined = undefined;
-    const data = Array.from(keywordSetting.entries()).map(([ param, setting ]): VariantConfigurationOptions => {
-      let choice: VariantConfigurationOptions = {short : 'Unknown'};
+    const data = Array.from(keywordSetting.entries()).map(([param, setting]): VariantConfigurationOptions => {
+      let choice: VariantConfigurationOptions = {short: 'Unknown'};
 
       if (vars.has(param)) {
         const choices = vars.get(param)!.choices;
@@ -231,23 +231,23 @@ export class VariantManager implements vscode.Disposable {
   }
 
   mergeVariantConfigurations(options: VariantConfigurationOptions[]): VariantConfigurationOptions {
-    const init: VariantConfigurationOptions = {short : '', long : '', settings : {}};
+    const init: VariantConfigurationOptions = {short: '', long: '', settings: {}};
     return options.reduce((acc, el) => ({
-                            buildType : el.buildType || acc.buildType,
-                            generator : el.generator || acc.generator,
-                            linkage : el.linkage || acc.linkage,
-                            toolset : el.toolset || acc.toolset,
-                            settings : {...acc.settings, ...el.settings},
-                            short : [ acc.short, el.short ].join(' ').trim(),
-                            long : [ acc.long, el.long ].join(', '),
+                            buildType: el.buildType || acc.buildType,
+                            generator: el.generator || acc.generator,
+                            linkage: el.linkage || acc.linkage,
+                            toolset: el.toolset || acc.toolset,
+                            settings: {...acc.settings, ...el.settings},
+                            short: [acc.short, el.short].join(' ').trim(),
+                            long: [acc.long, el.long].join(', '),
                           }),
                           init);
   }
 
   get activeVariantOptions(): VariantConfigurationOptions {
     const invalid_variant = {
-      short : 'Unknown',
-      long : 'Unknwon',
+      short: 'Unknown',
+      long: 'Unknwon',
     };
     const kws = this.stateManager.activeVariantSettings;
     if (!kws) {
@@ -260,10 +260,10 @@ export class VariantManager implements vscode.Disposable {
 
     let options_or_error = this.variantConfigurationOptionsForKWs(kws);
     if (typeof options_or_error === 'string') {
-      log.warning("Last variant selection is incompatible with present variant definition.");
-      log.warning(">> " + options_or_error);
+      log.warning('Last variant selection is incompatible with present variant definition.');
+      log.warning('>> ' + options_or_error);
 
-      log.warning("Using default variant choices from variant definition.");
+      log.warning('Using default variant choices from variant definition.');
       const defaultKws = this.findDefaultChoiceCombination();
       options_or_error = this.variantConfigurationOptionsForKWs(defaultKws);
     }
@@ -279,16 +279,15 @@ export class VariantManager implements vscode.Disposable {
   async selectVariant() {
     const variants
         = Array.from(this._variants.entries())
-              .map(
-                  ([ key, variant ]) => Array.from(variant.choices.entries())
-                                            .map(([ value_name, value ]) => (
-                                                     {settingKey : key, settingValue : value_name, settings : value})));
+              .map(([key, variant]) => Array.from(variant.choices.entries())
+                                           .map(([value_name, value]) => (
+                                                    {settingKey: key, settingValue: value_name, settings: value})));
     const product = util.product(variants);
     const items: VariantCombination[]
         = product.map(optionset => ({
-                        label : optionset.map(o => o.settings.short).join(' + '),
-                        keywordSettings : this.transformChoiceCombinationToKeywordSettings(optionset),
-                        description : optionset.map(o => o.settings.long).join(' + '),
+                        label: optionset.map(o => o.settings.short).join(' + '),
+                        keywordSettings: this.transformChoiceCombinationToKeywordSettings(optionset),
+                        description: optionset.map(o => o.settings.long).join(' + '),
                       }));
     const chosen = await vscode.window.showQuickPick(items);
     if (!chosen) {
@@ -311,9 +310,9 @@ export class VariantManager implements vscode.Disposable {
   }
 
   findDefaultChoiceCombination(): Map<string, string> {
-    const defaults = util.map(this._variants.entries(), ([ option, definition ]) => ({
-                                                          settingKey : option,
-                                                          settingValue : definition.default_,
+    const defaults = util.map(this._variants.entries(), ([option, definition]) => ({
+                                                          settingKey: option,
+                                                          settingValue: definition.default_,
                                                         }));
     return this.transformChoiceCombinationToKeywordSettings(Array.from(defaults));
   }

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -81,12 +81,12 @@ export class VariantManager implements vscode.Disposable {
   private _variants: VariantSet = new Map();
 
   get onActiveVariantChanged() { return this._activeVariantChanged.event; }
-  private _activeVariantChanged = new vscode.EventEmitter<void>();
+  private readonly _activeVariantChanged = new vscode.EventEmitter<void>();
 
   /**
    * Watches for changes to the variants file on the filesystem
    */
-  private _variantFileWatcher = new MultiWatcher();
+  private readonly _variantFileWatcher = new MultiWatcher();
 
   dispose() {
     this._variantFileWatcher.dispose();
@@ -237,7 +237,7 @@ export class VariantManager implements vscode.Disposable {
                             generator : el.generator || acc.generator,
                             linkage : el.linkage || acc.linkage,
                             toolset : el.toolset || acc.toolset,
-                            settings : Object.assign({}, acc.settings, el.settings),
+                            settings : {...acc.settings, ...el.settings},
                             short : [ acc.short, el.short ].join(' ').trim(),
                             long : [ acc.long, el.long ].join(', '),
                           }),

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -231,13 +231,15 @@ export class VariantManager implements vscode.Disposable {
   }
 
   mergeVariantConfigurations(options: VariantConfigurationOptions[]): VariantConfigurationOptions {
-    const init: VariantConfigurationOptions = {short: '', long: '', settings: {}};
+    const init = {short: '', long: '', settings: {}} as any as VariantConfigurationOptions;
     return options.reduce((acc, el) => ({
                             buildType: el.buildType || acc.buildType,
                             generator: el.generator || acc.generator,
                             linkage: el.linkage || acc.linkage,
                             toolset: el.toolset || acc.toolset,
-                            settings: {...acc.settings, ...el.settings},
+                            // TS 2.4 doesn't like using object spread here, for some reason.
+                            // tslint:disable-next-line:prefer-object-spread
+                            settings: Object.assign({}, acc.settings, el.settings),
                             short: [acc.short, el.short].join(' ').trim(),
                             long: [acc.long, el.long].join(', '),
                           }),

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -188,7 +188,7 @@ export class VariantManager implements vscode.Disposable {
       sets.set(setting_name, {
         default_: def,
         description: desc,
-        choices: choices,
+        choices,
       });
     }
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -15,12 +15,12 @@ class EventDispatcher implements vscode.Disposable {
 }
 
 export class IndividualWatcher implements vscode.Disposable {
-  private _watcher = vscode.workspace.createFileSystemWatcher(this._pattern);
-  private _changeSub = this._watcher.onDidChange(e => this._disp.changeEvent.fire(e));
-  private _delSub = this._watcher.onDidDelete(e => this._disp.deleteEvent.fire(e));
-  private _createSub = this._watcher.onDidCreate(e => this._disp.createEvent.fire(e));
+  private readonly _watcher = vscode.workspace.createFileSystemWatcher(this._pattern);
+  private readonly _changeSub = this._watcher.onDidChange(e => this._disp.changeEvent.fire(e));
+  private readonly _delSub = this._watcher.onDidDelete(e => this._disp.deleteEvent.fire(e));
+  private readonly _createSub = this._watcher.onDidCreate(e => this._disp.createEvent.fire(e));
 
-  constructor(private _disp: EventDispatcher, private _pattern: string) {}
+  constructor(private readonly _disp: EventDispatcher, private readonly _pattern: string) {}
 
   dispose() {
     this._changeSub.dispose();
@@ -32,16 +32,16 @@ export class IndividualWatcher implements vscode.Disposable {
 }
 
 export class MultiWatcher implements vscode.Disposable {
-  private _watchers = new Set<IndividualWatcher>();
-  private _dispatcher = new EventDispatcher();
-  private _anyEventEmitter = new vscode.EventEmitter<vscode.Uri>();
+  private readonly _watchers = new Set<IndividualWatcher>();
+  private readonly _dispatcher = new EventDispatcher();
+  private readonly _anyEventEmitter = new vscode.EventEmitter<vscode.Uri>();
 
-  private _unregisterSub
+  private readonly _unregisterSub
       = this._dispatcher.disposeIndividualWatcherEvent.event(indiv => { this._watchers.delete(indiv); });
 
-  private _createSub = this.onCreate(e => this._anyEventEmitter.fire(e));
-  private _delSub = this.onDelete(e => this._anyEventEmitter.fire(e));
-  private _changeSub = this.onChange(e => this._anyEventEmitter.fire(e));
+  private readonly _createSub = this.onCreate(e => this._anyEventEmitter.fire(e));
+  private readonly _delSub = this.onDelete(e => this._anyEventEmitter.fire(e));
+  private readonly _changeSub = this.onChange(e => this._anyEventEmitter.fire(e));
 
   constructor(...patterns: string[]) {
     for (const pattern of patterns) {

--- a/test/extension_tests/index.ts
+++ b/test/extension_tests/index.ts
@@ -10,7 +10,7 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-var testRunner = require('vscode/lib/testrunner');
+let testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info

--- a/test/extension_tests/index.ts
+++ b/test/extension_tests/index.ts
@@ -10,7 +10,8 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-let testRunner = require('vscode/lib/testrunner');
+// tslint:disable-next-line:no-var-keyword
+var testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info

--- a/test/extension_tests/index.ts
+++ b/test/extension_tests/index.ts
@@ -15,8 +15,8 @@ let testRunner = require('vscode/lib/testrunner');
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
-  ui : 'tdd',       // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors : true  // colored output from test results
+  ui: 'tdd',       // the TDD UI is being used in extension.test.ts (suite, test, etc.)
+  useColors: true  // colored output from test results
 });
 
 module.exports = testRunner;

--- a/test/extension_tests/without_cmakelist_file/index.ts
+++ b/test/extension_tests/without_cmakelist_file/index.ts
@@ -10,7 +10,7 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-var testRunner = require('vscode/lib/testrunner');
+let testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info

--- a/test/extension_tests/without_cmakelist_file/index.ts
+++ b/test/extension_tests/without_cmakelist_file/index.ts
@@ -10,7 +10,8 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-let testRunner = require('vscode/lib/testrunner');
+// tslint:disable-next-line:no-var-keyword
+var testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info

--- a/test/extension_tests/without_cmakelist_file/index.ts
+++ b/test/extension_tests/without_cmakelist_file/index.ts
@@ -15,8 +15,8 @@ let testRunner = require('vscode/lib/testrunner');
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
-  ui : 'tdd',       // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors : true  // colored output from test results
+  ui: 'tdd',       // the TDD UI is being used in extension.test.ts (suite, test, etc.)
+  useColors: true  // colored output from test results
 });
 
 module.exports = testRunner;

--- a/test/extension_tests/without_cmakelist_file/test/no_kits_present.test.ts
+++ b/test/extension_tests/without_cmakelist_file/test/no_kits_present.test.ts
@@ -9,9 +9,9 @@ import {clearExistingKitConfigurationFile, getExtension} from '../../../test_hel
 // This tests will be skipped when a Visual Studio installation marker (Env.HasVs=true) is present.
 // It is not possible to hide an installation against the test. In that case
 // it is not possible to test a no present kit, because VS will provide always kits.
-(process.env.HasVs == 'true' ? suite.skip : suite)('No present kit', () => {
+(process.env.HasVs == 'true' ? suite.skip.bind(suite) : suite)('No present kit', () => {
   let path_backup = '';
-  suiteSetup(async() => {
+  suiteSetup(async () => {
     await clearExistingKitConfigurationFile();
 
     path_backup = process.env.PATH!;
@@ -24,20 +24,20 @@ import {clearExistingKitConfigurationFile, getExtension} from '../../../test_hel
     process.env.PATH = path_backup;
   });
 
-  test('Scan for no existing kit should return no selected kit', async() => {
+  test('Scan for no existing kit should return no selected kit', async () => {
     const cmt = await getExtension();
     await cmt.scanForKits();
     expect(await cmt.selectKit()).to.be.eq(null);
   });
 
-  test('Configure ', async() => {
+  test('Configure ', async () => {
     const cmt = await getExtension();
     await cmt.scanForKits();
 
     expect(await cmt.configure()).to.be.eq(-1);
   });
 
-  test('Build', async() => {
+  test('Build', async () => {
     const cmt = await getExtension();
     await cmt.scanForKits();
 

--- a/test/extension_tests/without_cmakelist_file/test/no_kits_present.test.ts
+++ b/test/extension_tests/without_cmakelist_file/test/no_kits_present.test.ts
@@ -11,8 +11,8 @@ import {clearExistingKitConfigurationFile, getExtension} from '../../../test_hel
 // it is not possible to test a no present kit, because VS will provide always kits.
 (process.env.HasVs == 'true' ? suite.skip : suite)('No present kit', () => {
   let path_backup = '';
-  suiteSetup(() => {
-    clearExistingKitConfigurationFile();
+  suiteSetup(async() => {
+    await clearExistingKitConfigurationFile();
 
     path_backup = process.env.PATH!;
     // The tests will use the PATH environment variable to scan for compilers,
@@ -22,7 +22,7 @@ import {clearExistingKitConfigurationFile, getExtension} from '../../../test_hel
   suiteTeardown(() => {
     // restores old path
     process.env.PATH = path_backup;
-  })
+  });
 
   test('Scan for no existing kit should return no selected kit', async() => {
     const cmt = await getExtension();

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -7,13 +7,13 @@ import paths from '../src/paths';
 import {fs} from '../src/pr';
 
 export async function clearExistingKitConfigurationFile() {
-  await fs.writeFile(path.join(paths.dataDir, 'cmake-kits.json'), "[]");
+  await fs.writeFile(path.join(paths.dataDir, 'cmake-kits.json'), '[]');
 }
 
 export async function getExtension() {
   const cmt = vscode.extensions.getExtension<CMakeTools>('vector-of-bool.cmake-tools');
   if (!cmt) {
-    throw new Error("Extension doesn't exist");
+    throw new Error('Extension doesn\'t exist');
   }
   return cmt.isActive ? Promise.resolve(cmt.exports) : cmt.activate();
 }

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -6,7 +6,9 @@ import {CMakeTools} from '../src/cmake-tools';
 import paths from '../src/paths';
 import {fs} from '../src/pr';
 
-export function clearExistingKitConfigurationFile() { fs.writeFile(path.join(paths.dataDir, 'cmake-kits.json'), "[]"); }
+export async function clearExistingKitConfigurationFile() {
+  await fs.writeFile(path.join(paths.dataDir, 'cmake-kits.json'), "[]");
+}
 
 export async function getExtension() {
   const cmt = vscode.extensions.getExtension<CMakeTools>('vector-of-bool.cmake-tools');

--- a/test/unit_tests/cache.test.ts
+++ b/test/unit_tests/cache.test.ts
@@ -17,9 +17,9 @@ function getTestResourceFilePath(filename: string): string {
 }
 
 suite('Cache test', async () => {
-  test("Read CMake Cache", async () => {
+  test('Read CMake Cache', async () => {
     const cache = await CMakeCache.fromPath(getTestResourceFilePath('TestCMakeCache.txt'));
-    const generator = cache.get("CMAKE_GENERATOR") as api.CacheEntry;
+    const generator = cache.get('CMAKE_GENERATOR') as api.CacheEntry;
     expect(generator.type).to.eq(api.CacheEntryType.Internal);
     expect(generator.key).to.eq('CMAKE_GENERATOR');
     expect(generator.as<string>()).to.eq('Ninja');
@@ -29,9 +29,9 @@ suite('Cache test', async () => {
     expect(build_testing.type).to.eq(api.CacheEntryType.Bool);
     expect(build_testing.as<boolean>()).to.be.true;
   });
-  test("Read cache with various newlines", async () => {
+  test('Read cache with various newlines', async () => {
     for (const newline of ['\n', '\r\n', '\r']) {
-      const str = [ '# This line is ignored', '// This line is docs', 'SOMETHING:STRING=foo', '' ].join(newline);
+      const str = ['# This line is ignored', '// This line is docs', 'SOMETHING:STRING=foo', ''].join(newline);
       const entries = CMakeCache.parseCache(str);
       expect(entries.size).to.eq(1);
       expect(entries.has('SOMETHING')).to.be.true;
@@ -60,7 +60,7 @@ suite('Cache test', async () => {
     }
   });
   test('Truthy values', () => {
-    const true_things = [ '1', 'ON', 'YES', 'Y', '112', 12, 'SOMETHING' ];
+    const true_things = ['1', 'ON', 'YES', 'Y', '112', 12, 'SOMETHING'];
     for (const thing of true_things) {
       expect(util.isTruthy(thing), `Check truthiness of ${thing}`).to.be.true;
     }

--- a/test/unit_tests/cache.test.ts
+++ b/test/unit_tests/cache.test.ts
@@ -56,13 +56,13 @@ suite('Cache test', async () => {
       false,
     ];
     for (const thing of false_things) {
-      expect(util.isTruthy(thing), 'Check false-iness of ' + thing).to.be.false;
+      expect(util.isTruthy(thing), `Check false-iness of ${thing}`).to.be.false;
     }
   });
   test('Truthy values', () => {
     const true_things = [ '1', 'ON', 'YES', 'Y', '112', 12, 'SOMETHING' ];
     for (const thing of true_things) {
-      expect(util.isTruthy(thing), 'Check truthiness of ' + thing).to.be.true;
+      expect(util.isTruthy(thing), `Check truthiness of ${thing}`).to.be.true;
     }
   });
 });

--- a/test/unit_tests/cache.test.ts
+++ b/test/unit_tests/cache.test.ts
@@ -9,14 +9,15 @@ import * as api from '../../src/api';
 import {CMakeCache} from '../../src/cache';
 import * as util from '../../src/util';
 
+// tslint:disable:no-unused-expression
 
 const here = __dirname;
 function getTestResourceFilePath(filename: string): string {
   return path.normalize(path.join(here, '../../../test/unit_tests', filename));
 }
 
-suite('Cache test', async() => {
-  test("Read CMake Cache", async function() {
+suite('Cache test', async () => {
+  test("Read CMake Cache", async () => {
     const cache = await CMakeCache.fromPath(getTestResourceFilePath('TestCMakeCache.txt'));
     const generator = cache.get("CMAKE_GENERATOR") as api.CacheEntry;
     expect(generator.type).to.eq(api.CacheEntryType.Internal);
@@ -24,11 +25,11 @@ suite('Cache test', async() => {
     expect(generator.as<string>()).to.eq('Ninja');
     expect(typeof generator.value).to.eq('string');
 
-    const build_testing = await cache.get('BUILD_TESTING') as api.CacheEntry;
+    const build_testing = cache.get('BUILD_TESTING') as api.CacheEntry;
     expect(build_testing.type).to.eq(api.CacheEntryType.Bool);
     expect(build_testing.as<boolean>()).to.be.true;
   });
-  test("Read cache with various newlines", async function() {
+  test("Read cache with various newlines", async () => {
     for (const newline of ['\n', '\r\n', '\r']) {
       const str = [ '# This line is ignored', '// This line is docs', 'SOMETHING:STRING=foo', '' ].join(newline);
       const entries = CMakeCache.parseCache(str);

--- a/test/unit_tests/compilation_info.test.ts
+++ b/test/unit_tests/compilation_info.test.ts
@@ -9,6 +9,8 @@ import {expect} from 'chai';
 import * as api from '../../src/api';
 import * as compdb from '../../src/compdb';
 
+// tslint:disable:no-unused-expression
+
 const here = __dirname;
 function getTestResourceFilePath(filename: string): string {
   return path.normalize(path.join(here, '../../../test/unit_tests', filename));

--- a/test/unit_tests/compilation_info.test.ts
+++ b/test/unit_tests/compilation_info.test.ts
@@ -17,7 +17,7 @@ function getTestResourceFilePath(filename: string): string {
 }
 
 suite('Compilation info', () => {
-  test('Parsing compilation databases', async() => {
+  test('Parsing compilation databases', async () => {
     const dbpath = getTestResourceFilePath('test_compdb.json');
     const db = (await compdb.CompilationDatabase.fromFilePath(dbpath))!;
     expect(db).to.not.be.null;

--- a/test/unit_tests/compilation_info.test.ts
+++ b/test/unit_tests/compilation_info.test.ts
@@ -21,21 +21,21 @@ suite('Compilation info', () => {
     const dbpath = getTestResourceFilePath('test_compdb.json');
     const db = (await compdb.CompilationDatabase.fromFilePath(dbpath))!;
     expect(db).to.not.be.null;
-    const source_path = "/home/clang-languageservice/main.cpp";
+    const source_path = '/home/clang-languageservice/main.cpp';
     const info = db.getCompilationInfoForUri(vscode.Uri.file(source_path))!;
     expect(info).to.not.be.null;
     expect(info.file).to.eq(source_path);
     expect(info.compile!.directory).to.eq('/home/clang-languageservice/build');
     expect(info.compile!.command)
         .to.eq(
-            "/usr/local/bin/clang++   -DBOOST_THREAD_VERSION=3 -isystem ../extern/nlohmann-json/src  -g   -std=gnu++11 -o CMakeFiles/clang-languageservice.dir/main.cpp.o -c /home/clang-languageservice/main.cpp");
+            '/usr/local/bin/clang++   -DBOOST_THREAD_VERSION=3 -isystem ../extern/nlohmann-json/src  -g   -std=gnu++11 -o CMakeFiles/clang-languageservice.dir/main.cpp.o -c /home/clang-languageservice/main.cpp');
   });
   test('Parsing gnu-style compile info', () => {
     const raw: api.RawCompilationInfo = {
-      command :
+      command:
           'clang++ -I/foo/bar -isystem /system/path -fsome-compile-flag -DMACRO=DEFINITION -I ../relative/path "-I/path\\"with\\" embedded quotes/foo"',
-      directory : '/some/dir',
-      file : 'meow.cpp'
+      directory: '/some/dir',
+      file: 'meow.cpp'
     };
     const info = compdb.parseRawCompilationInfo(raw);
     expect(raw.command).to.eq(info.compile!.command);
@@ -59,10 +59,10 @@ suite('Compilation info', () => {
 
   test('Parsing MSVC-style compile info', () => {
     const raw: api.RawCompilationInfo = {
-      command :
+      command:
           'cl.exe -I/foo/bar /I/system/path /Z+:some-compile-flag /DMACRO=DEFINITION -I ../relative/path "/I/path\\"with\\" embedded quotes/foo"',
-      directory : '/some/dir',
-      file : 'meow.cpp'
+      directory: '/some/dir',
+      file: 'meow.cpp'
     };
     const info = compdb.parseRawCompilationInfo(raw);
     expect(raw.command).to.eq(info.compile!.command);

--- a/test/unit_tests/diagnostics.test.ts
+++ b/test/unit_tests/diagnostics.test.ts
@@ -28,7 +28,7 @@ function toLowerCaseForWindows(str: string): string {
   }
 }
 
-suite('Diagnostics', async() => {
+suite('Diagnostics', async () => {
   let consumer = new diags.CMakeOutputConsumer("dummyPath");
   let build_consumer = new diags.CompileOutputConsumer();
   setup(() => {
@@ -36,7 +36,7 @@ suite('Diagnostics', async() => {
     consumer = new diags.CMakeOutputConsumer("dummyPath");
     build_consumer = new diags.CompileOutputConsumer();
   });
-  test('Waring-free CMake output', async() => {
+  test('Waring-free CMake output', async () => {
     const cmake_output = [
       '-- Configuring done',
       '-- Generating done',

--- a/test/unit_tests/diagnostics.test.ts
+++ b/test/unit_tests/diagnostics.test.ts
@@ -21,7 +21,7 @@ function feedLines(consumer: OutputConsumer, output: string[], error: string[]) 
 }
 
 function toLowerCaseForWindows(str: string): string {
-  if (process.platform == "win32") {
+  if (process.platform == 'win32') {
     return str.toLowerCase();
   } else {
     return str;
@@ -29,11 +29,11 @@ function toLowerCaseForWindows(str: string): string {
 }
 
 suite('Diagnostics', async () => {
-  let consumer = new diags.CMakeOutputConsumer("dummyPath");
+  let consumer = new diags.CMakeOutputConsumer('dummyPath');
   let build_consumer = new diags.CompileOutputConsumer();
   setup(() => {
     // FIXME: SETUP IS NOT BEING CALLED
-    consumer = new diags.CMakeOutputConsumer("dummyPath");
+    consumer = new diags.CMakeOutputConsumer('dummyPath');
     build_consumer = new diags.CompileOutputConsumer();
   });
   test('Waring-free CMake output', async () => {
@@ -103,7 +103,7 @@ suite('Diagnostics', async () => {
     expect(consumer.diagnostics.length).to.eq(1);
     const warning = consumer.diagnostics[0];
     expect(warning.diag.severity).to.eq(vscode.DiagnosticSeverity.Warning);
-    expect(warning.diag.message).to.eq("I'm an inner warning");
+    expect(warning.diag.message).to.eq('I\'m an inner warning');
     expect(warning.diag.range.start.line).to.eq(14);
     expect(warning.diag.source).to.eq('CMake (message)');
   });
@@ -122,7 +122,7 @@ suite('Diagnostics', async () => {
     expect(consumer.diagnostics.length).to.eq(1);
     const warning = consumer.diagnostics[0];
     expect(warning.diag.severity).to.eq(vscode.DiagnosticSeverity.Warning);
-    expect(warning.diag.message).to.eq("I'm an inner warning");
+    expect(warning.diag.message).to.eq('I\'m an inner warning');
     expect(warning.diag.range.start.line).to.eq(14);
     expect(warning.diag.source).to.eq('CMake (message)');
   });
@@ -166,7 +166,7 @@ suite('Diagnostics', async () => {
   });
 
   test('Parse more GCC diagnostics', () => {
-    const lines = [ `/Users/Tobias/Code/QUIT/Source/qidespot1.cpp:303:49: error: expected ';' after expression` ];
+    const lines = [`/Users/Tobias/Code/QUIT/Source/qidespot1.cpp:303:49: error: expected ';' after expression`];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gccDiagnostics).to.have.length(1);
     const diag = build_consumer.gccDiagnostics[0];
@@ -178,7 +178,7 @@ suite('Diagnostics', async () => {
   });
 
   test('Parsing fatal error diagnostics', () => {
-    const lines = [ '/some/path/here:4:26: fatal error: some_header.h: No such file or directory' ];
+    const lines = ['/some/path/here:4:26: fatal error: some_header.h: No such file or directory'];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gccDiagnostics).to.have.length(1);
     const diag = build_consumer.gccDiagnostics[0];
@@ -193,8 +193,7 @@ suite('Diagnostics', async () => {
   });
 
   test('Parsing fatal error diagnostics in french', () => {
-    const lines =
-        [ '/home/romain/TL/test/base.c:2:21: erreur fatale : bonjour.h : Aucun fichier ou dossier de ce type' ];
+    const lines = ['/home/romain/TL/test/base.c:2:21: erreur fatale : bonjour.h : Aucun fichier ou dossier de ce type'];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gccDiagnostics).to.have.length(1);
     const diag = build_consumer.gccDiagnostics[0];
@@ -208,13 +207,13 @@ suite('Diagnostics', async () => {
     expect(path.posix.isAbsolute(diag.file)).to.be.true;
   });
   test('Parsing warning diagnostics', () => {
-    const lines = [ "/some/path/here:4:26: warning: unused parameter 'data'" ];
+    const lines = ['/some/path/here:4:26: warning: unused parameter \'data\''];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gccDiagnostics).to.have.length(1);
     const diag = build_consumer.gccDiagnostics[0];
 
     expect(diag.location.start.line).to.eq(3);
-    expect(diag.message).to.eq("unused parameter 'data'");
+    expect(diag.message).to.eq('unused parameter \'data\'');
     expect(diag.location.start.character).to.eq(25);
     expect(diag.file).to.eq('/some/path/here');
     expect(diag.severity).to.eq('warning');
@@ -222,7 +221,7 @@ suite('Diagnostics', async () => {
     expect(path.posix.isAbsolute(diag.file)).to.be.true;
   });
   test('Parsing warning diagnostics 2', () => {
-    const lines = [ `/test/main.cpp:21:14: warning: unused parameter ‘v’ [-Wunused-parameter]` ];
+    const lines = [`/test/main.cpp:21:14: warning: unused parameter ‘v’ [-Wunused-parameter]`];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gccDiagnostics).to.have.length(1);
     const diag = build_consumer.gccDiagnostics[0];
@@ -234,7 +233,7 @@ suite('Diagnostics', async () => {
     expect(diag.severity).to.eq('warning');
   });
   test('Parsing warning diagnostics in french', () => {
-    const lines = [ '/home/romain/TL/test/base.c:155:2: attention : déclaration implicite de la fonction ‘create’' ];
+    const lines = ['/home/romain/TL/test/base.c:155:2: attention : déclaration implicite de la fonction ‘create’'];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gccDiagnostics).to.have.length(1);
     const diag = build_consumer.gccDiagnostics[0];
@@ -248,26 +247,26 @@ suite('Diagnostics', async () => {
     expect(path.posix.isAbsolute(diag.file)).to.be.true;
   });
   test('Parsing linker error', () => {
-    const lines = [ "/some/path/here:101: undefined reference to `some_function'" ];
+    const lines = ['/some/path/here:101: undefined reference to `some_function\''];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gnuLDDiagnostics).to.have.length(1);
     const diag = build_consumer.gnuLDDiagnostics[0];
 
     expect(diag.location.start.line).to.eq(100);
-    expect(diag.message).to.eq("undefined reference to `some_function'");
+    expect(diag.message).to.eq('undefined reference to `some_function\'');
     expect(diag.file).to.eq('/some/path/here');
     expect(diag.severity).to.eq('error');
     expect(path.posix.normalize(diag.file)).to.eq(diag.file);
     expect(path.posix.isAbsolute(diag.file)).to.be.true;
   });
   test('Parsing linker error in french', () => {
-    const lines = [ "/home/romain/TL/test/test_fa_tp4.c:9 : référence indéfinie vers « create_automaton_product56 »" ];
+    const lines = ['/home/romain/TL/test/test_fa_tp4.c:9 : référence indéfinie vers « create_automaton_product56 »'];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.gnuLDDiagnostics).to.have.length(1);
     const diag = build_consumer.gnuLDDiagnostics[0];
 
     expect(diag.location.start.line).to.eq(8);
-    expect(diag.message).to.eq("référence indéfinie vers « create_automaton_product56 »");
+    expect(diag.message).to.eq('référence indéfinie vers « create_automaton_product56 »');
     expect(diag.file).to.eq('/home/romain/TL/test/test_fa_tp4.c');
     expect(diag.severity).to.eq('error');
     expect(path.posix.normalize(diag.file)).to.eq(diag.file);
@@ -306,7 +305,7 @@ suite('Diagnostics', async () => {
     expect(path.win32.isAbsolute(diag.file)).to.be.true;
   });
   test('Parsing GHS Diagnostics fatal error', () => {
-    const lines = [ '"C:\\path\\source\\debug\\debug.c", line 631 (col. 3): fatal error #68: some fatal error' ];
+    const lines = ['"C:\\path\\source\\debug\\debug.c", line 631 (col. 3): fatal error #68: some fatal error'];
     feedLines(build_consumer, [], lines);
     expect(build_consumer.ghsDiagnostics).to.have.length(1);
     const diag = build_consumer.ghsDiagnostics[0];

--- a/test/unit_tests/diagnostics.test.ts
+++ b/test/unit_tests/diagnostics.test.ts
@@ -9,6 +9,7 @@ import {expect} from 'chai';
 import * as diags from '../../src/diagnostics';
 import {OutputConsumer} from '../../src/proc';
 
+// tslint:disable:no-unused-expression
 
 function feedLines(consumer: OutputConsumer, output: string[], error: string[]) {
   for (const line of output) {

--- a/test/unit_tests/index.ts
+++ b/test/unit_tests/index.ts
@@ -10,7 +10,7 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-var testRunner = require('vscode/lib/testrunner');
+let testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info

--- a/test/unit_tests/index.ts
+++ b/test/unit_tests/index.ts
@@ -10,7 +10,8 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-let testRunner = require('vscode/lib/testrunner');
+// tslint:disable-next-line:no-var-keyword
+var testRunner = require('vscode/lib/testrunner');
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info

--- a/test/unit_tests/index.ts
+++ b/test/unit_tests/index.ts
@@ -15,8 +15,8 @@ let testRunner = require('vscode/lib/testrunner');
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
-  ui : 'tdd',       // the TDD UI is being used in extension.test.ts (suite, test, etc.)
-  useColors : true  // colored output from test results
+  ui: 'tdd',       // the TDD UI is being used in extension.test.ts (suite, test, etc.)
+  useColors: true  // colored output from test results
 });
 
 module.exports = testRunner;

--- a/test/unit_tests/kit_scan.test.ts
+++ b/test/unit_tests/kit_scan.test.ts
@@ -15,6 +15,8 @@ import * as kit from '../../src/kit';
 import {fs} from '../../src/pr';
 import * as state from '../../src/state';
 
+// tslint:disable:no-unused-expression
+
 const here = __dirname;
 function getTestRootFilePath(filename: string): string {
   return path.normalize(path.join(here, '../../..', 'test', filename));
@@ -35,17 +37,17 @@ function getPathWithoutCompilers() {
   }
 }
 
-suite('Kits scan test', async() => {
+suite('Kits scan test', async () => {
   const fakebin = getTestRootFilePath('fakebin');
   test('Detect system kits never throws',
-       async() => {
+       async () => {
          // Don't care about the result, just check that we don't throw during the test
          await expect(kit.scanForKits()).to.eventually.not.be.rejected;
        })
       // Compiler detection can run a little slow
       .timeout(12000);
 
-  test('Detect a GCC compiler file', async() => {
+  test('Detect a GCC compiler file', async () => {
     const compiler = path.join(fakebin, 'gcc-42.1');
     const compkit = await kit.kitIfCompiler(compiler);
     expect(compkit).to.not.be.null;
@@ -54,7 +56,7 @@ suite('Kits scan test', async() => {
     expect(compkit!.name).to.eq('GCC 42.1');
   });
 
-  test('Detect a Clang compiler file', async() => {
+  test('Detect a Clang compiler file', async () => {
     const compiler = path.join(fakebin, 'clang-0.25');
     const compkit = await kit.kitIfCompiler(compiler);
     expect(compkit).to.not.be.null;
@@ -63,67 +65,64 @@ suite('Kits scan test', async() => {
     expect(compkit!.name).to.eq('Clang 0.25');
   });
 
-  test('Detect non-compiler program', async() => {
+  test('Detect non-compiler program', async () => {
     const program = path.join(fakebin, 'gcc-666');
     const nil = await kit.kitIfCompiler(program);
     expect(nil).to.be.null;
   });
 
-  test('Detect non existing program', async() => {
+  test('Detect non existing program', async () => {
     const program = path.join(fakebin, 'unknown');
     const nil = await kit.kitIfCompiler(program);
     expect(nil).to.be.null;
   });
 
-  test('Scan non exisiting dir for kits', async() => {
+  test('Scan non exisiting dir for kits', async () => {
     const kits = await kit.scanDirForCompilerKits('');
     expect(kits.length).to.eq(0);
   });
 
-  suite('Scan directory', async() => {
+  suite('Scan directory', async () => {
     let path_with_compilername = '';
-    setup(async() => { path_with_compilername = path.join(fakebin, "gcc-4.3.2"); });
-    teardown(async() => {
+    setup(async () => { path_with_compilername = path.join(fakebin, "gcc-4.3.2"); });
+    teardown(async () => {
       if (await fs.exists(path_with_compilername)) {
-        await fs.rmdir(path_with_compilername)
+        await fs.rmdir(path_with_compilername);
       }
     });
-    test('Scan folder with compiler name', async() => {
-      fs.mkdir(path_with_compilername)
-          // Scan the directory with fake compilers in it
-          const kits
-          = await kit.scanDirForCompilerKits(fakebin);
+    test('Scan folder with compiler name', async () => {
+      await fs.mkdir(path_with_compilername);
+      // Scan the directory with fake compilers in it
+      const kits = await kit.scanDirForCompilerKits(fakebin);
       expect(kits.length).to.eq(2);
     });
 
-    test('Scan file with compiler name', async() => {
+    test('Scan file with compiler name', async () => {
       await fs.writeFile(path_with_compilername, '')
-          // Scan the directory with fake compilers in it
-          const kits
-          = await kit.scanDirForCompilerKits(fakebin);
+      // Scan the directory with fake compilers in it
+      const kits = await kit.scanDirForCompilerKits(fakebin);
       expect(kits.length).to.eq(2);
     });
   });
 
-  suite('Rescan kits', async() => {
+  suite('Rescan kits', async () => {
     let km: kit.KitManager;
     let path_rescan_kit = getTestResourceFilePath('rescan_kit.json');
     let sandbox: sinon.SinonSandbox;
     let path_backup: string|undefined;
-    setup(async() => {
+    setup(async () => {
       sandbox = sinon.sandbox.create();
       let stateMock = sandbox.createStubInstance(state.StateManager);
-      sandbox.stub(stateMock, 'activeKitName').get(function() { return null; }).set(function() {});
+      sandbox.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
       km = new kit.KitManager(stateMock, path_rescan_kit);
 
       // Mock showInformationMessage to suppress needed user choice
-      sandbox.stub(vscode.window, "showInformationMessage").callsFake(function() {
-        return {title : "No", isCloseAffordance : true, doOpen : false};
-      });
+      sandbox.stub(vscode.window, "showInformationMessage")
+          .callsFake(() => ({title : "No", isCloseAffordance : true, doOpen : false}));
 
       path_backup = process.env.PATH;
     });
-    teardown(async() => {
+    teardown(async () => {
       sandbox.restore();
       if (await fs.exists(path_rescan_kit)) {
         await fs.rmdir(path_rescan_kit)
@@ -131,21 +130,20 @@ suite('Kits scan test', async() => {
       process.env.PATH = path_backup;
     });
 
-    async function readValidKitFile(file_path: string):
-        Promise<any[]> {
-          const rawKitsFromFile = (await fs.readFile(file_path, 'utf8'));
-          expect(rawKitsFromFile.length).to.be.not.eq(0);
+    async function readValidKitFile(file_path: string): Promise<any[]> {
+      const rawKitsFromFile = (await fs.readFile(file_path, 'utf8'));
+      expect(rawKitsFromFile.length).to.be.not.eq(0);
 
-          let kitFile = json5.parse(rawKitsFromFile);
+      let kitFile = json5.parse(rawKitsFromFile);
 
-          const schema = json5.parse(await fs.readFile(getResourcePath('schemas/kits-schema.json'), 'utf8'));
-          const validator = new ajv({allErrors : true, format : 'full'}).compile(schema);
-          expect(validator(kitFile)).to.be.true;
+      const schema = json5.parse(await fs.readFile(getResourcePath('schemas/kits-schema.json'), 'utf8'));
+      const validator = new ajv({allErrors : true, format : 'full'}).compile(schema);
+      expect(validator(kitFile)).to.be.true;
 
-          return kitFile;
-        }
+      return kitFile;
+    }
 
-    test('init kit file creation no compilers in path', async() => {
+    test('init kit file creation no compilers in path', async () => {
       process.env['PATH'] = getPathWithoutCompilers();
 
       await km.initialize();
@@ -154,13 +152,13 @@ suite('Kits scan test', async() => {
       expect(newKitFileExists).to.be.true;
     }).timeout(10000);
 
-    test('check valid kit file for test system compilers', async() => {
+    test('check valid kit file for test system compilers', async () => {
       await km.initialize();
 
       await readValidKitFile(path_rescan_kit);
     }).timeout(30000);
 
-    test('check empty kit file no compilers in path', async() => {
+    test('check empty kit file no compilers in path', async () => {
       process.env['PATH'] = getPathWithoutCompilers();
 
       await km.initialize();
@@ -171,7 +169,7 @@ suite('Kits scan test', async() => {
     }).timeout(10000);
 
     // Fails because PATH is tried to split but a empty path is not splitable
-    test.skip('check empty kit file', async() => {
+    test.skip('check empty kit file', async () => {
       process.env['PATH'] = '';
 
       await km.initialize();
@@ -180,7 +178,7 @@ suite('Kits scan test', async() => {
       expect(newKitFileExists).to.be.true;
     });
 
-    test('check fake compilers in kit file', async() => {
+    test('check fake compilers in kit file', async () => {
       process.env['PATH'] = getTestRootFilePath("fakebin");
 
       await km.initialize();
@@ -190,7 +188,7 @@ suite('Kits scan test', async() => {
       expect(nonVSKits.length).to.be.eq(2);
     }).timeout(10000);
 
-    test('check check combination of scan and old kits', async() => {
+    test('check check combination of scan and old kits', async () => {
       process.env['PATH'] = getTestRootFilePath("fakebin");
       await fs
           .copyFile(getTestResourceFilePath('test_kit.json'), path_rescan_kit)
@@ -198,8 +196,7 @@ suite('Kits scan test', async() => {
               await km.initialize();
       await km.rescanForKits()
 
-          let names
-          = km.kits.map((item) => {return item.name});
+      let names = km.kits.map((item) => {return item.name});
 
       expect(names).to.contains("CompilerKit 1");
       expect(names).to.contains("CompilerKit 2");

--- a/test/unit_tests/kit_scan.test.ts
+++ b/test/unit_tests/kit_scan.test.ts
@@ -31,9 +31,9 @@ function getResourcePath(filename: string): string { return path.normalize(path.
 
 function getPathWithoutCompilers() {
   if (process.arch == "win32") {
-    return "C:\\TMP"
+    return "C:\\TMP";
   } else {
-    return "/tmp"
+    return "/tmp";
   }
 }
 
@@ -98,7 +98,7 @@ suite('Kits scan test', async () => {
     });
 
     test('Scan file with compiler name', async () => {
-      await fs.writeFile(path_with_compilername, '')
+      await fs.writeFile(path_with_compilername, '');
       // Scan the directory with fake compilers in it
       const kits = await kit.scanDirForCompilerKits(fakebin);
       expect(kits.length).to.eq(2);
@@ -125,7 +125,7 @@ suite('Kits scan test', async () => {
     teardown(async () => {
       sandbox.restore();
       if (await fs.exists(path_rescan_kit)) {
-        await fs.rmdir(path_rescan_kit)
+        await fs.rmdir(path_rescan_kit);
       }
       process.env.PATH = path_backup;
     });
@@ -190,11 +190,10 @@ suite('Kits scan test', async () => {
 
     test('check check combination of scan and old kits', async () => {
       process.env['PATH'] = getTestRootFilePath("fakebin");
-      await fs
-          .copyFile(getTestResourceFilePath('test_kit.json'), path_rescan_kit)
+      await fs.copyFile(getTestResourceFilePath('test_kit.json'), path_rescan_kit);
 
-              await km.initialize();
-      await km.rescanForKits()
+      await km.initialize();
+      await km.rescanForKits();
 
       const names = km.kits.map(item => item.name);
 

--- a/test/unit_tests/kit_scan.test.ts
+++ b/test/unit_tests/kit_scan.test.ts
@@ -30,10 +30,10 @@ function getTestResourceFilePath(filename: string): string {
 function getResourcePath(filename: string): string { return path.normalize(path.join(here, '../../..', filename)); }
 
 function getPathWithoutCompilers() {
-  if (process.arch == "win32") {
-    return "C:\\TMP";
+  if (process.arch == 'win32') {
+    return 'C:\\TMP';
   } else {
-    return "/tmp";
+    return '/tmp';
   }
 }
 
@@ -84,7 +84,7 @@ suite('Kits scan test', async () => {
 
   suite('Scan directory', async () => {
     let path_with_compilername = '';
-    setup(async () => { path_with_compilername = path.join(fakebin, "gcc-4.3.2"); });
+    setup(async () => { path_with_compilername = path.join(fakebin, 'gcc-4.3.2'); });
     teardown(async () => {
       if (await fs.exists(path_with_compilername)) {
         await fs.rmdir(path_with_compilername);
@@ -117,8 +117,8 @@ suite('Kits scan test', async () => {
       km = new kit.KitManager(stateMock, path_rescan_kit);
 
       // Mock showInformationMessage to suppress needed user choice
-      sandbox.stub(vscode.window, "showInformationMessage")
-          .callsFake(() => ({title : "No", isCloseAffordance : true, doOpen : false}));
+      sandbox.stub(vscode.window, 'showInformationMessage')
+          .callsFake(() => ({title: 'No', isCloseAffordance: true, doOpen: false}));
 
       path_backup = process.env.PATH;
     });
@@ -137,7 +137,7 @@ suite('Kits scan test', async () => {
       const kitFile = json5.parse(rawKitsFromFile);
 
       const schema = json5.parse(await fs.readFile(getResourcePath('schemas/kits-schema.json'), 'utf8'));
-      const validator = new ajv({allErrors : true, format : 'full'}).compile(schema);
+      const validator = new ajv({allErrors: true, format: 'full'}).compile(schema);
       expect(validator(kitFile)).to.be.true;
 
       return kitFile;
@@ -179,7 +179,7 @@ suite('Kits scan test', async () => {
     });
 
     test('check fake compilers in kit file', async () => {
-      process.env['PATH'] = getTestRootFilePath("fakebin");
+      process.env['PATH'] = getTestRootFilePath('fakebin');
 
       await km.initialize();
 
@@ -189,7 +189,7 @@ suite('Kits scan test', async () => {
     }).timeout(10000);
 
     test('check check combination of scan and old kits', async () => {
-      process.env['PATH'] = getTestRootFilePath("fakebin");
+      process.env['PATH'] = getTestRootFilePath('fakebin');
       await fs.copyFile(getTestResourceFilePath('test_kit.json'), path_rescan_kit);
 
       await km.initialize();
@@ -197,14 +197,14 @@ suite('Kits scan test', async () => {
 
       const names = km.kits.map(item => item.name);
 
-      expect(names).to.contains("CompilerKit 1");
-      expect(names).to.contains("CompilerKit 2");
-      expect(names).to.contains("CompilerKit 3 with PreferedGenerator");
-      expect(names).to.contains("ToolchainKit 1");
-      expect(names).to.contains("VSCode Kit 1");
-      expect(names).to.contains("VSCode Kit 2");
-      expect(names).to.contains("Clang 0.25");
-      expect(names).to.contains("GCC 42.1");
+      expect(names).to.contains('CompilerKit 1');
+      expect(names).to.contains('CompilerKit 2');
+      expect(names).to.contains('CompilerKit 3 with PreferedGenerator');
+      expect(names).to.contains('ToolchainKit 1');
+      expect(names).to.contains('VSCode Kit 1');
+      expect(names).to.contains('VSCode Kit 2');
+      expect(names).to.contains('Clang 0.25');
+      expect(names).to.contains('GCC 42.1');
     }).timeout(10000);
   });
 });

--- a/test/unit_tests/kit_scan.test.ts
+++ b/test/unit_tests/kit_scan.test.ts
@@ -107,12 +107,12 @@ suite('Kits scan test', async () => {
 
   suite('Rescan kits', async () => {
     let km: kit.KitManager;
-    let path_rescan_kit = getTestResourceFilePath('rescan_kit.json');
+    const path_rescan_kit = getTestResourceFilePath('rescan_kit.json');
     let sandbox: sinon.SinonSandbox;
     let path_backup: string|undefined;
     setup(async () => {
       sandbox = sinon.sandbox.create();
-      let stateMock = sandbox.createStubInstance(state.StateManager);
+      const stateMock = sandbox.createStubInstance(state.StateManager);
       sandbox.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
       km = new kit.KitManager(stateMock, path_rescan_kit);
 
@@ -134,7 +134,7 @@ suite('Kits scan test', async () => {
       const rawKitsFromFile = (await fs.readFile(file_path, 'utf8'));
       expect(rawKitsFromFile.length).to.be.not.eq(0);
 
-      let kitFile = json5.parse(rawKitsFromFile);
+      const kitFile = json5.parse(rawKitsFromFile);
 
       const schema = json5.parse(await fs.readFile(getResourcePath('schemas/kits-schema.json'), 'utf8'));
       const validator = new ajv({allErrors : true, format : 'full'}).compile(schema);
@@ -163,8 +163,8 @@ suite('Kits scan test', async () => {
 
       await km.initialize();
 
-      let kitFile = await readValidKitFile(path_rescan_kit);
-      let nonVSKits = kitFile.filter((item) => {return item.visualStudio == null});
+      const kitFile = await readValidKitFile(path_rescan_kit);
+      const nonVSKits = kitFile.filter(item => item.visualStudio == null);
       expect(nonVSKits.length).to.be.eq(0);
     }).timeout(10000);
 
@@ -183,8 +183,8 @@ suite('Kits scan test', async () => {
 
       await km.initialize();
 
-      let kitFile = await readValidKitFile(path_rescan_kit);
-      let nonVSKits = kitFile.filter((item) => {return item.visualStudio == null});
+      const kitFile = await readValidKitFile(path_rescan_kit);
+      const nonVSKits = kitFile.filter(item => item.visualStudio == null);
       expect(nonVSKits.length).to.be.eq(2);
     }).timeout(10000);
 
@@ -196,7 +196,7 @@ suite('Kits scan test', async () => {
               await km.initialize();
       await km.rescanForKits()
 
-      let names = km.kits.map((item) => {return item.name});
+      const names = km.kits.map(item => item.name);
 
       expect(names).to.contains("CompilerKit 1");
       expect(names).to.contains("CompilerKit 2");

--- a/test/unit_tests/kitmanager.test.ts
+++ b/test/unit_tests/kitmanager.test.ts
@@ -35,9 +35,9 @@ suite('Kits test', async () => {
 
     test('KitManager tests opening of kit file', async () => {
       let text: vscode.TextDocument|undefined;
-      gui_sandbox.stub(vscode.window, "showTextDocument").callsFake(textDoc => {
+      gui_sandbox.stub(vscode.window, 'showTextDocument').callsFake(textDoc => {
         text = textDoc;
-        return {document : textDoc};
+        return {document: textDoc};
       });
       await km.initialize();
 
@@ -81,12 +81,12 @@ suite('Kits test', async () => {
     await km.initialize();
 
     expect(km.kits.length).to.eq(6);
-    expect(km.kits[0].name).to.eq("CompilerKit 1");
-    expect(km.kits[1].name).to.eq("CompilerKit 2");
-    expect(km.kits[2].name).to.eq("CompilerKit 3 with PreferedGenerator");
-    expect(km.kits[3].name).to.eq("ToolchainKit 1");
-    expect(km.kits[4].name).to.eq("VSCode Kit 1");
-    expect(km.kits[5].name).to.eq("VSCode Kit 2");
+    expect(km.kits[0].name).to.eq('CompilerKit 1');
+    expect(km.kits[1].name).to.eq('CompilerKit 2');
+    expect(km.kits[2].name).to.eq('CompilerKit 3 with PreferedGenerator');
+    expect(km.kits[3].name).to.eq('ToolchainKit 1');
+    expect(km.kits[4].name).to.eq('VSCode Kit 1');
+    expect(km.kits[5].name).to.eq('VSCode Kit 2');
 
     km.dispose();
   });
@@ -94,14 +94,14 @@ suite('Kits test', async () => {
   test('KitManager test selection of last activated kit', async () => {
     const stateMock = sinon.createStubInstance(state.StateManager);
 
-    sinon.stub(stateMock, 'activeKitName').get(() => "ToolchainKit 1").set(() => {});
+    sinon.stub(stateMock, 'activeKitName').get(() => 'ToolchainKit 1').set(() => {});
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
 
     await km.initialize();
 
     expect(km.activeKit).to.be.not.null;
     if (km.activeKit)
-      expect(km.activeKit.name).to.eq("ToolchainKit 1");
+      expect(km.activeKit.name).to.eq('ToolchainKit 1');
 
     km.dispose();
   });
@@ -119,8 +119,8 @@ suite('Kits test', async () => {
 
   test('KitManager test selection of default kit if last activated kit is invalid', async () => {
     const stateMock = sinon.createStubInstance(state.StateManager);
-    let storedActivatedKitName = "not replaced";
-    sinon.stub(stateMock, 'activeKitName').get(() => "Unknown").set(kit_ => storedActivatedKitName = kit_);
+    let storedActivatedKitName = 'not replaced';
+    sinon.stub(stateMock, 'activeKitName').get(() => 'Unknown').set(kit_ => storedActivatedKitName = kit_);
 
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
     await km.initialize();

--- a/test/unit_tests/kitmanager.test.ts
+++ b/test/unit_tests/kitmanager.test.ts
@@ -12,6 +12,7 @@ import * as kit from '../../src/kit';
 import {fs} from '../../src/pr';
 import * as state from '../../src/state';
 
+// tslint:disable:no-unused-expression
 
 const here = __dirname;
 function getTestResourceFilePath(filename: string): string {
@@ -26,7 +27,7 @@ suite('Kits test', async() => {
     setup(async() => {
       gui_sandbox = sinon.sandbox.create();
       let stateMock = gui_sandbox.createStubInstance(state.StateManager);
-      sinon.stub(stateMock, 'activeKitName').get(function() { return null; }).set(function() {});
+      sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
       const kit_file = getTestResourceFilePath('test_kit.json');
       km = new kit.KitManager(stateMock, kit_file);
     });
@@ -34,10 +35,7 @@ suite('Kits test', async() => {
 
     test('KitManager tests opening of kit file', async() => {
       let text: vscode.TextDocument|undefined;
-      gui_sandbox.stub(vscode.window, "showTextDocument").callsFake(function(textDoc) {
-        text = textDoc;
-        return {document : text};
-      });
+      gui_sandbox.stub(vscode.window, "showTextDocument").callsFake(textDoc => ({document : textDoc}));
       await km.initialize();
 
       const editor = await km.openKitsEditor();
@@ -54,9 +52,7 @@ suite('Kits test', async() => {
   test('KitManager tests event on change of active kit', async() => {
     let stateMock = sinon.createStubInstance(state.StateManager);
     let storedActivatedKitName: string = '';
-    sinon.stub(stateMock, 'activeKitName').get(function() { return null; }).set(function(kit) {
-      storedActivatedKitName = kit;
-    });
+    sinon.stub(stateMock, 'activeKitName').get(() => null).set(kit => storedActivatedKitName = kit);
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
     await km.initialize();
     // Check that each time we change the kit, it fires a signal
@@ -76,7 +72,7 @@ suite('Kits test', async() => {
 
   test('KitManager test load of kit from test file', async() => {
     let stateMock = sinon.createStubInstance(state.StateManager);
-    sinon.stub(stateMock, 'activeKitName').get(function() { return null; }).set(function() {});
+    sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
 
     await km.initialize();
@@ -95,7 +91,7 @@ suite('Kits test', async() => {
   test('KitManager test selection of last activated kit', async() => {
     let stateMock = sinon.createStubInstance(state.StateManager);
 
-    sinon.stub(stateMock, 'activeKitName').get(function() { return "ToolchainKit 1"; }).set(function() {});
+    sinon.stub(stateMock, 'activeKitName').get(() => "ToolchainKit 1").set(() => { });
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
 
     await km.initialize();
@@ -109,7 +105,7 @@ suite('Kits test', async() => {
 
   test('KitManager test selection of a default kit', async() => {
     let stateMock = sinon.createStubInstance(state.StateManager);
-    sinon.stub(stateMock, 'activeKitName').get(function() { return null; }).set(function() {});
+    sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
 
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
     await km.initialize();
@@ -121,9 +117,7 @@ suite('Kits test', async() => {
   test('KitManager test selection of default kit if last activated kit is invalid', async() => {
     let stateMock = sinon.createStubInstance(state.StateManager);
     let storedActivatedKitName = "not replaced";
-    sinon.stub(stateMock, 'activeKitName').get(function() { return "Unknown"; }).set(function(kit) {
-      storedActivatedKitName = kit;
-    });
+    sinon.stub(stateMock, 'activeKitName').get(() => "Unknown").set(kit => storedActivatedKitName = kit);
 
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
     await km.initialize();

--- a/test/unit_tests/kitmanager.test.ts
+++ b/test/unit_tests/kitmanager.test.ts
@@ -35,7 +35,10 @@ suite('Kits test', async() => {
 
     test('KitManager tests opening of kit file', async() => {
       let text: vscode.TextDocument|undefined;
-      gui_sandbox.stub(vscode.window, "showTextDocument").callsFake(textDoc => ({document : textDoc}));
+      gui_sandbox.stub(vscode.window, "showTextDocument").callsFake(textDoc => {
+        text = textDoc;
+        return {document : textDoc};
+      });
       await km.initialize();
 
       const editor = await km.openKitsEditor();

--- a/test/unit_tests/kitmanager.test.ts
+++ b/test/unit_tests/kitmanager.test.ts
@@ -55,14 +55,14 @@ suite('Kits test', async() => {
   test('KitManager tests event on change of active kit', async() => {
     let stateMock = sinon.createStubInstance(state.StateManager);
     let storedActivatedKitName: string = '';
-    sinon.stub(stateMock, 'activeKitName').get(() => null).set(kit => storedActivatedKitName = kit);
+    sinon.stub(stateMock, 'activeKitName').get(() => null).set(kit_ => storedActivatedKitName = kit_);
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
     await km.initialize();
     // Check that each time we change the kit, it fires a signal
     let fired_kit: string|null = null;
     km.onActiveKitChanged(k => fired_kit = k!.name);
-    for (const kit of km.kits) {
-      const name = kit.name;
+    for (const kit_el of km.kits) {
+      const name = kit_el.name;
       // Set the kit
       await km.selectKitByName(name);
       // Check that we got the signal
@@ -120,7 +120,7 @@ suite('Kits test', async() => {
   test('KitManager test selection of default kit if last activated kit is invalid', async() => {
     let stateMock = sinon.createStubInstance(state.StateManager);
     let storedActivatedKitName = "not replaced";
-    sinon.stub(stateMock, 'activeKitName').get(() => "Unknown").set(kit => storedActivatedKitName = kit);
+    sinon.stub(stateMock, 'activeKitName').get(() => "Unknown").set(kit_ => storedActivatedKitName = kit_);
 
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
     await km.initialize();

--- a/test/unit_tests/kitmanager.test.ts
+++ b/test/unit_tests/kitmanager.test.ts
@@ -20,20 +20,20 @@ function getTestResourceFilePath(filename: string): string {
 }
 
 
-suite('Kits test', async() => {
-  suite('GUI test', async() => {
+suite('Kits test', async () => {
+  suite('GUI test', async () => {
     let km: kit.KitManager;
     let gui_sandbox: sinon.SinonSandbox;
-    setup(async() => {
+    setup(async () => {
       gui_sandbox = sinon.sandbox.create();
-      let stateMock = gui_sandbox.createStubInstance(state.StateManager);
+      const stateMock = gui_sandbox.createStubInstance(state.StateManager);
       sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
       const kit_file = getTestResourceFilePath('test_kit.json');
       km = new kit.KitManager(stateMock, kit_file);
     });
-    teardown(async() => { gui_sandbox.restore(); });
+    teardown(async () => { gui_sandbox.restore(); });
 
-    test('KitManager tests opening of kit file', async() => {
+    test('KitManager tests opening of kit file', async () => {
       let text: vscode.TextDocument|undefined;
       gui_sandbox.stub(vscode.window, "showTextDocument").callsFake(textDoc => {
         text = textDoc;
@@ -44,7 +44,7 @@ suite('Kits test', async() => {
       const editor = await km.openKitsEditor();
 
       expect(text).to.be.not.undefined;
-      if (text != undefined) {
+      if (text !== undefined) {
         const rawKitsFromFile = (await fs.readFile(getTestResourceFilePath('test_kit.json'), 'utf8'));
         expect(editor.document.getText()).to.be.eq(rawKitsFromFile);
       } else {
@@ -52,8 +52,8 @@ suite('Kits test', async() => {
     }).timeout(10000);
   });
 
-  test('KitManager tests event on change of active kit', async() => {
-    let stateMock = sinon.createStubInstance(state.StateManager);
+  test('KitManager tests event on change of active kit', async () => {
+    const stateMock = sinon.createStubInstance(state.StateManager);
     let storedActivatedKitName: string = '';
     sinon.stub(stateMock, 'activeKitName').get(() => null).set(kit_ => storedActivatedKitName = kit_);
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
@@ -73,8 +73,8 @@ suite('Kits test', async() => {
     km.dispose();
   }).timeout(10000);
 
-  test('KitManager test load of kit from test file', async() => {
-    let stateMock = sinon.createStubInstance(state.StateManager);
+  test('KitManager test load of kit from test file', async () => {
+    const stateMock = sinon.createStubInstance(state.StateManager);
     sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
 
@@ -91,10 +91,10 @@ suite('Kits test', async() => {
     km.dispose();
   });
 
-  test('KitManager test selection of last activated kit', async() => {
-    let stateMock = sinon.createStubInstance(state.StateManager);
+  test('KitManager test selection of last activated kit', async () => {
+    const stateMock = sinon.createStubInstance(state.StateManager);
 
-    sinon.stub(stateMock, 'activeKitName').get(() => "ToolchainKit 1").set(() => { });
+    sinon.stub(stateMock, 'activeKitName').get(() => "ToolchainKit 1").set(() => {});
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
 
     await km.initialize();
@@ -106,8 +106,8 @@ suite('Kits test', async() => {
     km.dispose();
   });
 
-  test('KitManager test selection of a default kit', async() => {
-    let stateMock = sinon.createStubInstance(state.StateManager);
+  test('KitManager test selection of a default kit', async () => {
+    const stateMock = sinon.createStubInstance(state.StateManager);
     sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
 
     const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
@@ -117,8 +117,8 @@ suite('Kits test', async() => {
     km.dispose();
   });
 
-  test('KitManager test selection of default kit if last activated kit is invalid', async() => {
-    let stateMock = sinon.createStubInstance(state.StateManager);
+  test('KitManager test selection of default kit if last activated kit is invalid', async () => {
+    const stateMock = sinon.createStubInstance(state.StateManager);
     let storedActivatedKitName = "not replaced";
     sinon.stub(stateMock, 'activeKitName').get(() => "Unknown").set(kit_ => storedActivatedKitName = kit_);
 

--- a/tslint.json
+++ b/tslint.json
@@ -16,6 +16,18 @@
 		"no-shadowed-variable": true,
 		"no-return-await": true,
 		"no-string-throw": true,
-		"no-switch-case-fall-through": true
+		"no-switch-case-fall-through": true,
+		"no-unbound-method": true,
+		"no-this-assignment": true,
+		"no-unnecessary-class": true,
+		"no-unsafe-finally": true,
+		"no-var-keyword": true,
+		"prefer-object-spread": true,
+		"restrict-plus-operands": true,
+		"strict-type-predicates": true,
+		"prefer-const": true,
+		"prefer-readonly": true,
+		"arrow-parens": [true, "ban-single-arg-parens"],
+		"arrow-return-shorthand": true
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,9 @@
 		"await-promise": [true, "Thenable", "PromisedAssertion"],
 		"ban-comma-operator": true,
 		"no-console": [true, "info", "error", "warn"],
-		"no-floating-promises": [true, "PromisedAssertion"]
+		"no-floating-promises": [true, "PromisedAssertion"],
+		"no-implicit-dependencies": [true, "dev"],
+		"no-shadowed-variable": true,
+		"no-return-await": true
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,7 @@
 		"no-unused-variable": true,
 		"curly": false,
 		"class-name": true,
-		"semicolon": ["always"],
+		"semicolon": [true, "always"],
 		"prefer-for-of": true,
 		"only-arrow-functions": [true, "allow-declarations"],
 		"await-promise": [true, "Thenable", "PromisedAssertion"],

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,8 @@
 		"no-floating-promises": [true, "PromisedAssertion"],
 		"no-implicit-dependencies": [true, "dev"],
 		"no-shadowed-variable": true,
-		"no-return-await": true
+		"no-return-await": true,
+		"no-string-throw": true,
+		"no-switch-case-fall-through": true
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,11 @@
 		"curly": false,
 		"class-name": true,
 		"semicolon": ["always"],
-		"triple-equals": true
+		"prefer-for-of": true,
+		"only-arrow-functions": [true, "allow-declarations"],
+		"await-promise": [true, "Thenable", "PromisedAssertion"],
+		"ban-comma-operator": true,
+		"no-console": [true, "info", "error", "warn"],
+		"no-floating-promises": [true, "PromisedAssertion"]
 	}
 }

--- a/tslint.json
+++ b/tslint.json
@@ -28,6 +28,12 @@
 		"prefer-const": true,
 		"prefer-readonly": true,
 		"arrow-parens": [true, "ban-single-arg-parens"],
-		"arrow-return-shorthand": true
+		"arrow-return-shorthand": true,
+		"no-boolean-literal-compare": true,
+		"no-angle-bracket-type-assertion": true,
+		"no-trailing-whitespace": true,
+		"object-literal-shorthand": true,
+		"object-literal-key-quotes": [true, "as-needed"],
+		"prefer-template": [true, "allow-single-concat"]
 	}
 }


### PR DESCRIPTION
### This changes the linting and formatting rules

The following changes are proposed:

- Run tslint on Travis
- Adds several stylistic _and_ behavioral lint rules.
- `.clang-format` is now a bit more sane.

## Other Notes/Information

Unfortunately, this PR touches almost every single file. May create a bit of a merge nightmare, but I hope that once this is done once it'll never be required to touch every single file again.

I chose a subset of the TSLint rules that I found compelling. Please feel free to suggest adding/removing any rules.