### PR TITLE
[beta4] Possible vswhere UTF-8 fix & Differentiate between release and pre-release installations

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -369,6 +369,11 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   selectKit() { return this._kitManager.selectKit(); }
 
   /**
+   * Primarily a helper function for the preferred-generators tests
+   */
+  getKits() { return this._kitManager.kits; }
+
+  /**
    * The `DiagnosticCollection` for the CMake configure diagnostics.
    */
   private readonly _configureDiagnostics = vscode.languages.createDiagnosticCollection('cmake-configure-diags');

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -8,7 +8,9 @@ import config from './config';
 import {CMakeGenerator} from './kit';
 import {createLogger} from './logging';
 import {fs} from './pr';
+import * as proc from './proc';
 import rollbar from './rollbar';
+import * as util from './util';
 
 const log = createLogger('cms-client');
 
@@ -509,9 +511,10 @@ export class CMakeServerClient {
       pipe_file = `/tmp/cmake-server-${Math.random()}`;
     }
     this._pipeFilePath = pipe_file;
+    const final_env = util.mergeEnvironment(process.env as proc.EnvironmentVariables, params.environment);
     const child = this._proc
         = child_proc.spawn(params.cmakePath, ['-E', 'server', '--experimental', `--pipe=${pipe_file}`], {
-            env: params.environment,
+            env: final_env,
           });
     log.debug(`Started new CMake Server instance with PID ${child.pid}`);
     child.stdout.on('data', this._onErrorData.bind(this));

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -8,9 +8,7 @@ import config from './config';
 import {CMakeGenerator} from './kit';
 import {createLogger} from './logging';
 import {fs} from './pr';
-import * as proc from './proc';
 import rollbar from './rollbar';
-import * as util from './util';
 
 const log = createLogger('cms-client');
 
@@ -56,24 +54,18 @@ export interface ProtocolVersion {
 /**
  * The base of all messages. Each message has a `type` property.
  */
-export interface MessageBase {
-  type: string;
-}
+export interface MessageBase { type: string; }
 
 /**
  * Cookied messages represent some on-going conversation.
  */
-export interface CookiedMessage extends MessageBase {
-  cookie: string;
-}
+export interface CookiedMessage extends MessageBase { cookie: string; }
 
 /**
  * Reply messages are solicited by some previous request, which comes with a
  * cookie to identify the initiating request.
  */
-export interface ReplyMessage extends CookiedMessage {
-  inReplyTo: string;
-}
+export interface ReplyMessage extends CookiedMessage { inReplyTo: string; }
 
 /**
  * Progress messages are sent regarding some long-running request process before
@@ -92,9 +84,7 @@ export interface SignalMessage extends MessageBase {
   name: string;
 }
 
-export interface DirtyMessage extends SignalMessage {
-  name: 'dirty';
-}
+export interface DirtyMessage extends SignalMessage { name: 'dirty'; }
 
 export interface FileChangeMessage {
   name: 'fileChange';
@@ -138,24 +128,18 @@ export interface HandshakeParams {
   protocolVersion: {major: number; minor: number;};
 }
 
-export interface HandshakeRequest extends CookiedMessage, HandshakeParams {
-  type: 'handshake';
-}
+export interface HandshakeRequest extends CookiedMessage, HandshakeParams { type: 'handshake'; }
 
 export interface HandshakeContent {}
 
-export interface HandshakeReply extends ReplyMessage, HandshakeContent {
-  inReplyTo: 'handshake';
-}
+export interface HandshakeReply extends ReplyMessage, HandshakeContent { inReplyTo: 'handshake'; }
 
 /**
  * GlobalSettings request gets some static information about the project setup.
  */
 export interface GlobalSettingsParams {}
 
-export interface GlobalSettingsRequest extends CookiedMessage, GlobalSettingsParams {
-  type: 'globalSettings';
-}
+export interface GlobalSettingsRequest extends CookiedMessage, GlobalSettingsParams { type: 'globalSettings'; }
 
 export interface GlobalSettingsContent {
   buildDirectory: string;
@@ -176,9 +160,7 @@ export interface GlobalSettingsContent {
   warnUnusedCli: boolean;
 }
 
-export interface GlobalSettingsReply extends ReplyMessage, GlobalSettingsContent {
-  inReplyTo: 'globalSettings';
-}
+export interface GlobalSettingsReply extends ReplyMessage, GlobalSettingsContent { inReplyTo: 'globalSettings'; }
 
 /**
  * setGlobalSettings changes information about the project setup.
@@ -193,9 +175,7 @@ export interface SetGlobalSettingsParams {
   warnUnusedCli?: boolean;
 }
 
-export interface SetGlobalSettingsRequest extends CookiedMessage, SetGlobalSettingsParams {
-  type: 'setGlobalSettings';
-}
+export interface SetGlobalSettingsRequest extends CookiedMessage, SetGlobalSettingsParams { type: 'setGlobalSettings'; }
 
 export interface SetGlobalSettingsContent {}
 
@@ -207,33 +187,23 @@ export interface SetGlobalSettingsReply extends ReplyMessage, SetGlobalSettingsC
  * configure will actually do the configuration for the project. Note that
  * this should be followed shortly with a 'compute' request.
  */
-export interface ConfigureParams {
-  cacheArguments: string[];
-}
+export interface ConfigureParams { cacheArguments: string[]; }
 
-export interface ConfigureRequest extends CookiedMessage, ConfigureParams {
-  type: 'configure';
-}
+export interface ConfigureRequest extends CookiedMessage, ConfigureParams { type: 'configure'; }
 
 export interface ConfigureContent {}
-export interface ConfigureReply extends ReplyMessage, ConfigureContent {
-  inReplyTo: 'configure';
-}
+export interface ConfigureReply extends ReplyMessage, ConfigureContent { inReplyTo: 'configure'; }
 
 /**
  * Compute actually generates the build files from the configure step.
  */
 export interface ComputeParams {}
 
-export interface ComputeRequest extends CookiedMessage, ComputeParams {
-  type: 'compute';
-}
+export interface ComputeRequest extends CookiedMessage, ComputeParams { type: 'compute'; }
 
 export interface ComputeContent {}
 
-export interface ComputeReply extends ReplyMessage, ComputeContent {
-  inReplyTo: 'compute';
-}
+export interface ComputeReply extends ReplyMessage, ComputeContent { inReplyTo: 'compute'; }
 
 /**
  * codemodel gets information about the project, such as targets, files,
@@ -242,9 +212,7 @@ export interface ComputeReply extends ReplyMessage, ComputeContent {
  */
 export interface CodeModelParams {}
 
-export interface CodeModelRequest extends CookiedMessage, CodeModelParams {
-  type: 'codemodel';
-}
+export interface CodeModelRequest extends CookiedMessage, CodeModelParams { type: 'codemodel'; }
 
 export interface CodeModelFileGroup {
   language: string;
@@ -284,13 +252,9 @@ export interface CodeModelConfiguration {
   projects: CodeModelProject[];
 }
 
-export interface CodeModelContent {
-  configurations: CodeModelConfiguration[];
-}
+export interface CodeModelContent { configurations: CodeModelConfiguration[]; }
 
-export interface CodeModelReply extends ReplyMessage, CodeModelContent {
-  inReplyTo: 'codemodel';
-}
+export interface CodeModelReply extends ReplyMessage, CodeModelContent { inReplyTo: 'codemodel'; }
 
 /**
  * cmakeInputs will respond with a list of file paths that can alter a
@@ -299,9 +263,7 @@ export interface CodeModelReply extends ReplyMessage, CodeModelContent {
  */
 export interface CMakeInputsParams {}
 
-export interface CMakeInputsRequest extends CookiedMessage, CMakeInputsParams {
-  type: 'cmakeInputs';
-}
+export interface CMakeInputsRequest extends CookiedMessage, CMakeInputsParams { type: 'cmakeInputs'; }
 
 export interface CMakeInputsContent {
   buildFiles: {isCMake: boolean; isTemporary: boolean; sources: string[];}[];
@@ -309,22 +271,16 @@ export interface CMakeInputsContent {
   sourceDirectory: string;
 }
 
-export interface CMakeInputsReply extends ReplyMessage, CMakeInputsContent {
-  inReplyTo: 'cmakeInputs';
-}
+export interface CMakeInputsReply extends ReplyMessage, CMakeInputsContent { inReplyTo: 'cmakeInputs'; }
 
 /**
  * The cache request will respond with the contents of the CMake cache.
  */
 export interface CacheParams {}
 
-export interface CacheRequest extends CookiedMessage, CacheParams {
-  type: 'cache';
-}
+export interface CacheRequest extends CookiedMessage, CacheParams { type: 'cache'; }
 
-export interface CacheContent {
-  cache: CMakeCacheEntry[];
-}
+export interface CacheContent { cache: CMakeCacheEntry[]; }
 
 export interface CMakeCacheEntry {
   key: string;
@@ -333,9 +289,7 @@ export interface CMakeCacheEntry {
   value: string;
 }
 
-export interface CacheReply extends ReplyMessage, CacheContent {
-  inReplyTo: 'cache';
-}
+export interface CacheReply extends ReplyMessage, CacheContent { inReplyTo: 'cache'; }
 
 // Union type that represents any of the request types.
 export type SomeRequestMessage
@@ -555,10 +509,9 @@ export class CMakeServerClient {
       pipe_file = `/tmp/cmake-server-${Math.random()}`;
     }
     this._pipeFilePath = pipe_file;
-    const final_env = util.mergeEnvironment(process.env as proc.EnvironmentVariables, params.environment);
     const child = this._proc
         = child_proc.spawn(params.cmakePath, ['-E', 'server', '--experimental', `--pipe=${pipe_file}`], {
-            env: final_env,
+            env: params.environment,
           });
     log.debug(`Started new CMake Server instance with PID ${child.pid}`);
     child.stdout.on('data', this._onErrorData.bind(this));

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -534,7 +534,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
           return platform === 'win32' && this.testHaveCommand('nmake', ['/?']);
         }
         if (gen_name == 'Unix Makefiles') {
-          return platform !== 'win32' && this.testHaveCommand('make');
+          return await this.testHaveCommand('make') && !(await this.testHaveCommand('mingw32-make'));
         }
         return false;
       })();

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -525,7 +525,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       const gen_name = gen.name;
       const generator_present = await (async(): Promise<boolean> => {
         if (gen_name == 'Ninja') {
-          return await this.testHaveCommand('ninja-build') || this.testHaveCommand('ninja');
+          return await this.testHaveCommand('ninja') || this.testHaveCommand('ninja-build');
         }
         if (gen_name == 'MinGW Makefiles') {
           return platform === 'win32' && await this.testHaveCommand('make') || this.testHaveCommand('mingw32-make');
@@ -534,7 +534,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
           return platform === 'win32' && this.testHaveCommand('nmake', ['/?']);
         }
         if (gen_name == 'Unix Makefiles') {
-          return await this.testHaveCommand('make') && !(await this.testHaveCommand('mingw32-make'));
+          return !(await this.testHaveCommand('mingw32-make')) && this.testHaveCommand('make');
         }
         return false;
       })();

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -528,13 +528,13 @@ export abstract class CMakeDriver implements vscode.Disposable {
           return await this.testHaveCommand('ninja') || this.testHaveCommand('ninja-build');
         }
         if (gen_name == 'MinGW Makefiles') {
-          return platform === 'win32' && await this.testHaveCommand('make') || this.testHaveCommand('mingw32-make');
+          return platform === 'win32' && this.testHaveCommand('mingw32-make');
         }
         if (gen_name == 'NMake Makefiles') {
           return platform === 'win32' && this.testHaveCommand('nmake', ['/?']);
         }
         if (gen_name == 'Unix Makefiles') {
-          return !(await this.testHaveCommand('mingw32-make')) && this.testHaveCommand('make');
+          return this.testHaveCommand('make');
         }
         return false;
       })();

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -299,8 +299,9 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const installs = [] as VSInstallation[];
   const inst_ids = [] as string[];
   const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
-  const vswhere_args = ['-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease'];
-  const vswhere_res = await proc.execute(vswhere_exe, vswhere_args, null, {silent: true, encoding: 'utf8'}).result;
+  const vswhere_args =
+      ['/c', 'chcp 65001 |', vswhere_exe, '-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease'];
+  const vswhere_res = await proc.execute('cmd.exe', vswhere_args, null, {silent: true, encoding: 'utf8'}).result;
 
   if (vswhere_res.retc !== 0) {
     log.error('Failed to execute vswhere.exe:', vswhere_res.stdout);

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -465,7 +465,7 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
         platform: VsArchitectures[arch] as string || undefined,
       };
     }
-    log.debug(` Selected Prefered Generator Name: ${generatorName}`);
+    log.debug(` Selected Preferred Generator Name: ${generatorName}`);
   }
 
   return kit;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -300,11 +300,8 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const inst_ids = [] as string[];
   const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
   const vswhere_args = ['-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease'];
-  const vswhere_res = await proc.executeFile(vswhere_exe, vswhere_args).result;
-  if (vswhere_res.retc !== 0) {
-    log.error('Failed to execute vswhere.exe:', vswhere_res.stdout);
-    return [];
-  }
+  const vswhere_res = await proc.executeFile(vswhere_exe, vswhere_args);
+
   const vs_installs = JSON.parse(vswhere_res.stdout) as VSInstallation[];
   for (const inst of vs_installs) {
     if (inst_ids.indexOf(inst.instanceId) < 0) {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -300,7 +300,7 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const inst_ids = [] as string[];
   const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
   const vswhere_args = ['-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease'];
-  const vswhere_res = await proc.execute(vswhere_exe, vswhere_args, null, {encoding: 'utf8'}).result;
+  const vswhere_res = await proc.execute(vswhere_exe, vswhere_args, null, {silent: true, encoding: 'utf8'}).result;
 
   if (vswhere_res.retc !== 0) {
     log.error('Failed to execute vswhere.exe:', vswhere_res.stdout);

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -364,7 +364,7 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
   const fname = Math.random().toString() + '.bat';
   const batpath = path.join(paths.tmpDir, `vs-cmt-${fname}`);
   await fs.writeFile(batpath, bat.join('\r\n'));
-  const res = await proc.execute(batpath, [], null, {shell: true}).result;
+  const res = await proc.execute(batpath, [], null, {shell: true, silent: true}).result;
   await fs.unlink(batpath);
   const output = res.stdout;
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -344,6 +344,7 @@ const MSVC_ENVIRONMENT_VARIABLES = [
   'WINDOWSSDKDIR',
   'WINDOWSSDKLIBVERSION',
   'WINDOWSSDKVERSION',
+  'VISUALSTUDIOVERSION'
 ];
 
 /**
@@ -417,6 +418,17 @@ async function varsForVSInstallation(inst: VSInstallation, arch: string): Promis
   if (!variables) {
     return null;
   } else {
+    // This is a very *hacky* and sub-optimal solution, but it
+    // works for now. This *helps* CMake make the right decision
+    // when you have the release and pre-release edition of the same
+    // VS version installed. I don't really know why or what causes
+    // this issue, but this here seems to work. It basically just sets
+    // the VS{vs_version_number}COMNTOOLS environment variable to contain
+    // the path to the Common7 directory.
+    const vs_version = variables.get('VISUALSTUDIOVERSION');
+    if (vs_version)
+      variables.set(`VS${vs_version.replace('.', '')}COMNTOOLS`, common_dir);
+
     // For Ninja and Makefile generators, CMake searches for some compilers
     // before it checks for cl.exe. We can force CMake to check cl.exe first by
     // setting the CC and CXX environment variables when we want to do a

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -301,18 +301,8 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
   const sys32_path = path.join(process.env.WINDIR as string, 'System32');
 
-  const vswhere_args = [
-    '/c',
-    `${sys32_path}\\chcp 65001 |`,
-    vswhere_exe,
-    '-all',
-    '-format',
-    'json',
-    '-products',
-    '*',
-    '-legacy',
-    '-prerelease'
-  ];
+  const vswhere_args =
+      ['/c', `${sys32_path}\\chcp 65001 | ${vswhere_exe} -all -format json -products * -legacy -prerelease`];
   const vswhere_res
       = await proc.execute(`${sys32_path}\\cmd.exe`, vswhere_args, null, {silent: true, encoding: 'utf8'}).result;
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -299,12 +299,25 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const installs = [] as VSInstallation[];
   const inst_ids = [] as string[];
   const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
-  const vswhere_args =
-      ['/c', 'chcp 65001 |', vswhere_exe, '-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease'];
-  const vswhere_res = await proc.execute('cmd.exe', vswhere_args, null, {silent: true, encoding: 'utf8'}).result;
+  const sys32_path = path.join(process.env.WINDIR as string, 'System32');
+
+  const vswhere_args = [
+    '/c',
+    `${sys32_path}\\chcp 65001 |`,
+    vswhere_exe,
+    '-all',
+    '-format',
+    'json',
+    '-products',
+    '*',
+    '-legacy',
+    '-prerelease'
+  ];
+  const vswhere_res
+      = await proc.execute(`${sys32_path}\\cmd.exe`, vswhere_args, null, {silent: true, encoding: 'utf8'}).result;
 
   if (vswhere_res.retc !== 0) {
-    log.error('Failed to execute vswhere.exe:', vswhere_res.stdout);
+    log.error('Failed to execute vswhere.exe:', vswhere_res.stderr);
     return [];
   }
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -367,17 +367,20 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
   const res = await proc.execute(batpath, [], null, {shell: true}).result;
   await fs.unlink(batpath);
   const output = res.stdout;
+
   if (res.retc !== 0) {
+    if (output.includes('Invalid host architecture') || output.includes('Error in script usage'))
+      return;
+
     console.log(`Error running ${devbat}`, output);
     return;
   }
-  if (output.includes('Invalid host architecture') || output.includes('Error in script usage')) {
-    return;
-  }
+
   if (!output) {
     console.log(`Environment detection for using ${devbat} failed`);
     return;
   }
+
   const vars
       = output.split('\n').map(l => l.trim()).filter(l => l.length !== 0).reduce<Map<string, string>>((acc, line) => {
           const mat = /(\w+) := ?(.*)/.exec(line);
@@ -388,6 +391,7 @@ async function collectDevBatVars(devbat: string, args: string[]): Promise<Map<st
           }
           return acc;
         }, new Map());
+
   return vars;
 }
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -300,7 +300,12 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const inst_ids = [] as string[];
   const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
   const vswhere_args = ['-all', '-format', 'json', '-products', '*', '-legacy', '-prerelease'];
-  const vswhere_res = await proc.executeFile(vswhere_exe, vswhere_args);
+  const vswhere_res = await proc.execute(vswhere_exe, vswhere_args, null, {encoding: 'utf8'}).result;
+
+  if (vswhere_res.retc !== 0) {
+    log.error('Failed to execute vswhere.exe:', vswhere_res.stdout);
+    return [];
+  }
 
   const vs_installs = JSON.parse(vswhere_res.stdout) as VSInstallation[];
   for (const inst of vs_installs) {

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -63,15 +63,21 @@ export interface Subprocess {
   child: proc.ChildProcess;
 }
 
-export interface EnvironmentVariables {
-  [key: string]: string;
-}
+export interface EnvironmentVariables { [key: string]: string; }
 
 export interface ExecutionOptions {
   environment?: EnvironmentVariables;
   shell?: boolean;
   silent?: boolean;
   cwd?: string;
+}
+
+export interface ExecFileOptions {
+  environment?: EnvironmentVariables;
+  shell?: string;
+  silent?: boolean;
+  cwd?: string;
+  encoding?: BufferEncoding;
 }
 
 /**
@@ -111,6 +117,97 @@ export function execute(command: string,
     spawn_opts.cwd = options.cwd;
   }
   const child: proc.ChildProcess = proc.spawn(command, args, spawn_opts);
+  const result = new Promise<ExecutionResult>((resolve, reject) => {
+    child.on('error', err => { reject(err); });
+    let stdout_acc = '';
+    let line_acc = '';
+    let stderr_acc = '';
+    let stderr_line_acc = '';
+    child.stdout.on('data', (data: Uint8Array) => {
+      const str = data.toString();
+      const lines = str.split('\n').map(l => l.endsWith('\r') ? l.substr(0, l.length - 1) : l);
+      while (lines.length > 1) {
+        line_acc += lines[0];
+        if (outputConsumer) {
+          outputConsumer.output(line_acc);
+        }
+        line_acc = '';
+        // Erase the first line from the list
+        lines.splice(0, 1);
+      }
+      console.assert(lines.length, 'Invalid lines', JSON.stringify(lines));
+      line_acc += lines[0];
+      stdout_acc += str;
+    });
+    child.stderr.on('data', (data: Uint8Array) => {
+      const str = data.toString();
+      const lines = str.split('\n').map(l => l.endsWith('\r') ? l.substr(0, l.length - 1) : l);
+      while (lines.length > 1) {
+        stderr_line_acc += lines[0];
+        if (outputConsumer) {
+          outputConsumer.error(stderr_line_acc);
+        }
+        stderr_line_acc = '';
+        // Erase the first line from the list
+        lines.splice(0, 1);
+      }
+      console.assert(lines.length, 'Invalid lines', JSON.stringify(lines));
+      stderr_line_acc += lines[0];
+      stderr_acc += str;
+    });
+    // Don't stop until the child stream is closed, otherwise we might not read
+    // the whole output of the command.
+    child.on('close', retc => {
+      if (line_acc && outputConsumer) {
+        outputConsumer.output(line_acc);
+      }
+      if (stderr_line_acc && outputConsumer) {
+        outputConsumer.error(stderr_line_acc);
+      }
+      resolve({retc, stdout: stdout_acc, stderr: stderr_acc});
+    });
+  });
+  return {child, result};
+}
+
+/**
+ * Execute a command and return the result
+ * @param command The binary to execute
+ * @param args The arguments to pass to the binary
+ * @param outputConsumer An output consumer for the command execution
+ * @param options Additional execution options
+ *
+ * @note Output from the command is accumulated into a single buffer: Commands
+ * which produce a lot of output should be careful about memory constraints.
+ */
+export function executeFile(command: string,
+                            args: string[],
+                            outputConsumer?: OutputConsumer|null,
+                            options?: ExecFileOptions): Subprocess {
+  if (options && options.silent !== true) {
+    log.info('Executing command: '
+             // We do simple quoting of arguments with spaces.
+             // This is only shown to the user,
+             // and doesn't have to be 100% correct.
+             + [command]
+                   .concat(args)
+                   .map(a => a.replace('"', '\"'))
+                   .map(a => /[ \n\r\f;\t]/.test(a) ? `"${a}"` : a)
+                   .join(' '));
+  }
+  if (!options) {
+    options = {};
+  }
+  const final_env = util.mergeEnvironment(process.env as EnvironmentVariables, options.environment || {});
+
+  const exec_opts: proc.ExecOptionsWithStringEncoding
+      = {env: final_env, shell: options.shell, encoding: options.encoding || 'utf8'};
+
+  if (options && options.cwd) {
+    exec_opts.cwd = options.cwd;
+  }
+
+  const child: proc.ChildProcess = proc.execFile(command, args, exec_opts);
   const result = new Promise<ExecutionResult>((resolve, reject) => {
     child.on('error', err => { reject(err); });
     let stdout_acc = '';

--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -41,11 +41,11 @@ class RollbarController {
   async requestPermissions(extensionContext: vscode.ExtensionContext): Promise<void> {
     log.debug('Checking Rollbar permissions');
     if (process.env['CMT_TESTING'] === '1') {
-      log.warning('Running CMakeTools in test mode. Rollbar is disabled.');
+      log.trace('Running CMakeTools in test mode. Rollbar is disabled.');
       return;
     }
     if (process.env['CMT_DEVRUN'] === '1') {
-      log.warning('Running CMakeTools in developer mode. Rollbar reporting is disabled.');
+      log.trace('Running CMakeTools in developer mode. Rollbar reporting is disabled.');
       return;
     }
     // The memento key where we store permission. Update this to ask again.

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -149,7 +149,7 @@ export class VariantManager implements vscode.Disposable {
         if (filepath.endsWith('.json')) {
           new_variants = json5.parse(content);
         } else {
-          new_variants = yaml.load(content);
+          new_variants = yaml.load(content) as VariantFileContent;
         }
       } catch (e) { log.error(`Error parsing ${filepath}: ${e}`); }
     }

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -4,6 +4,7 @@ import {ITestCallbackContext} from 'mocha';
 
 interface KitEnvironment {
   defaultKit: string;
+  excludeKit?: string;
   expectedDefaultGenerator: string;
   path?: string[];
 }
@@ -20,11 +21,23 @@ if (workername === undefined) {
 
 const VISUAL_STUDIO_KITS: KitEnvironment[] = [
   // Visual Studio 2017
-  {defaultKit: 'Visual Studio Community 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {
+    defaultKit: 'Visual Studio Community 2017',
+    excludeKit: 'Preview',
+    expectedDefaultGenerator: 'Visual Studio 15 2017'
+  },
   {defaultKit: 'Visual Studio Community 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
-  {defaultKit: 'Visual Studio Professional 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {
+    defaultKit: 'Visual Studio Professional 2017',
+    excludeKit: 'Preview',
+    expectedDefaultGenerator: 'Visual Studio 15 2017'
+  },
   {defaultKit: 'Visual Studio Professional 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
-  {defaultKit: 'Visual Studio Enterprise 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {
+    defaultKit: 'Visual Studio Enterprise 2017',
+    excludeKit: 'Preview',
+    expectedDefaultGenerator: 'Visual Studio 15 2017'
+  },
   {defaultKit: 'Visual Studio Enterprise 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
 
   // Visual Studio 2015
@@ -35,34 +48,39 @@ const VISUAL_STUDIO_KITS: KitEnvironment[] = [
 ];
 
 const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
-  ['windows']: VISUAL_STUDIO_KITS.concat([{
-    defaultKit: 'GCC',
-    expectedDefaultGenerator: 'MinGW Makefiles',
-    path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-  }]),
+  ['windows']: VISUAL_STUDIO_KITS.concat([
+    {
+      defaultKit: 'GCC 7.2.0',
+      expectedDefaultGenerator: 'MinGW Makefiles',
+      path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+    },
+    {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\temp']},
+    {defaultKit: 'Clang 4.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\temp']},
+    {defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\temp']}
+  ]),
   ['Visual Studio 2017']: VISUAL_STUDIO_KITS.concat([
     {
-      defaultKit: 'GCC',
+      defaultKit: 'GCC 7.2.0',
       expectedDefaultGenerator: 'MinGW Makefiles',
       path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
     },
-    {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles', path: ['C:\\cygwin64\\bin']}
+    {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\temp']}
   ]),
   ['Visual Studio 2017 Preview']: VISUAL_STUDIO_KITS.concat(
-      [{defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles', path: ['C:\\cygwin64\\bin']}]),
+      [{defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\temp']}]),
   ['Visual Studio 2015']: VISUAL_STUDIO_KITS.concat([
     {
-      defaultKit: 'GCC',
+      defaultKit: 'GCC 7.2.0',
       expectedDefaultGenerator: 'MinGW Makefiles',
       path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
     },
     {
-      defaultKit: 'GCC',
+      defaultKit: 'GCC 6.3.0',
       expectedDefaultGenerator: 'MinGW Makefiles',
       path: ['C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
     },
-    {defaultKit: 'GCC', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']},
-    {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles', path: ['C:\\cygwin64\\bin']}
+    {defaultKit: 'GCC 5.3.0', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']},
+    {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\temp']}
   ]),
   ['linux']: [
     {defaultKit: 'Clang', expectedDefaultGenerator: 'Unix Makefiles'},
@@ -135,7 +153,8 @@ function makeExtensionTestSuite(name: string,
       context.testEnv = new DefaultEnvironment('test/extension-tests/successful-build/project-folder',
                                                'build',
                                                'output.txt',
-                                               context.buildSystem.defaultKit);
+                                               context.buildSystem.defaultKit,
+                                               context.buildSystem.excludeKit);
 
       context.pathBackup = process.env.PATH!;
       if (context.buildSystem.path && context.buildSystem.path.length != 0) {

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -62,6 +62,11 @@ const DEFAULT_CYGWIN_KITS: KitEnvironment[] = [
 
 const DEFAULT_MINGW_KITS: KitEnvironment[] = [
   {
+    defaultKit: 'GCC 7.3.0',
+    expectedDefaultGenerator: 'MinGW Makefiles',
+    path: ['C:\\Program Files\\mingw-w64\\x86_64-7.3.0-posix-seh-rt_v5-rev0\\mingw64\\bin']
+  },
+  {
     defaultKit: 'GCC 7.2.0',
     expectedDefaultGenerator: 'MinGW Makefiles',
     path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -49,8 +49,8 @@ const DEFAULT_VS_KITS: KitEnvironment[] = [
 
 const DEFAULT_CYGWIN_KITS: KitEnvironment[] = [
   {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']},
-  {defaultKit: 'Clang 4.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']},
-  {defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
+  {defaultKit: 'Clang 4.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
+  //,{defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
 ];
 
 const DEFAULT_MINGW_KITS: KitEnvironment[] = [

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -136,7 +136,7 @@ function skipTestIf(skipOptions: SkipOptions, testContext: any, context: CMakeCo
 function makeExtensionTestSuite(name: string,
                                 expectedBuildSystem: KitEnvironment,
                                 cb: (context: CMakeContext) => void) {
-  suite.only(name, () => {
+  suite(name, () => {
     const context = {buildSystem: expectedBuildSystem} as CMakeContext;
 
     suiteSetup(async function(this: Mocha.IBeforeAndAfterContext) {

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -104,7 +104,7 @@ interface CMakeContext {
   buildSystem: KitEnvironment;
 }
 
-function checkKit(kitName: string, defaultKit: string, excludeKit?: string) {
+function checkKit(kitName: string, defaultKit: string, excludeKit?: string): boolean {
   return kitName.includes(defaultKit) && (excludeKit ? !kitName.includes(excludeKit) : true);
 }
 
@@ -150,7 +150,7 @@ function skipTestIf(skipOptions: SkipOptions, testContext: any, context: CMakeCo
 function makeExtensionTestSuite(name: string,
                                 expectedBuildSystem: KitEnvironment,
                                 cb: (context: CMakeContext) => void) {
-  suite.only(name, () => {
+  suite(name, () => {
     const context = {buildSystem: expectedBuildSystem} as CMakeContext;
 
     suiteSetup(async function(this: Mocha.IBeforeAndAfterContext) {

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -50,7 +50,6 @@ const DEFAULT_VS_KITS: KitEnvironment[] = [
 const DEFAULT_CYGWIN_KITS: KitEnvironment[] = [
   {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']},
   {defaultKit: 'Clang 4.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
-  //,{defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
 ];
 
 const DEFAULT_MINGW_KITS: KitEnvironment[] = [
@@ -75,7 +74,9 @@ const DEFAULT_MINGW_KITS: KitEnvironment[] = [
 const DEFAULT_WINDOWS_KITS: KitEnvironment[] = DEFAULT_VS_KITS.concat(DEFAULT_CYGWIN_KITS, DEFAULT_MINGW_KITS);
 
 const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
-  ['win32']: DEFAULT_WINDOWS_KITS,
+  ['win32']: DEFAULT_WINDOWS_KITS.concat([
+    {defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
+  ]),
   ['Visual Studio 2017']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2017 Preview']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2015']: DEFAULT_WINDOWS_KITS,

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -209,10 +209,10 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
 
            await context.cmt.selectKit();
            await context.testEnv.setting.changeSetting('preferredGenerators', []);
-           expect(await context.cmt.build()).to.be.eq(0);
+           expect(await context.cmt.build()).to.eql(0);
            const result = await context.testEnv.result.getResultAsJson();
-           expect(result['cmake-generator']).to.eq(buildSystem.expectedDefaultGenerator);
-           expect(context.testEnv.errorMessagesQueue.length).to.be.eq(0);
+           expect(result['cmake-generator']).to.eql(buildSystem.expectedDefaultGenerator);
+           expect(context.testEnv.errorMessagesQueue.length).to.eql(0);
          });
 
     test(`Use preferred generator from settings file (${buildSystem.defaultKit})`,
@@ -221,17 +221,16 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
 
            await context.cmt.selectKit();
            await context.testEnv.setting.changeSetting('preferredGenerators',
-                                                       ['Ninja', 'Unix Makefiles', 'MinGW Makefiles']);
-           expect(await context.cmt.build()).to.be.eq(0);
+                                                       ['NMake Makefiles', 'Unix Makefiles', 'MinGW Makefiles']);
+           expect(await context.cmt.build()).to.eql(0);
            const result = await context.testEnv.result.getResultAsJson();
 
-           // We expect the VS 2017 kits to use the Ninja generator
-           if (context.buildSystem.defaultKit.includes('2017'))
-             expect(result['cmake-generator']).to.eq('Ninja');
-           else
-             expect(result['cmake-generator']).to.eq(context.buildSystem.expectedDefaultGenerator);
+           expect(result['cmake-generator'])
+               .to.eql(context.buildSystem.defaultKit.includes('Visual Studio')
+                           ? 'NMake Makefiles'
+                           : context.buildSystem.expectedDefaultGenerator);
 
-           expect(context.testEnv.errorMessagesQueue.length).to.be.eq(0);
+           expect(context.testEnv.errorMessagesQueue.length).to.eql(0);
          });
 
     // This test is NOT valid for kits which have any preferred generator defined
@@ -276,7 +275,7 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
            const result = await context.testEnv.result.getResultAsJson();
            expect(result['cmake-generator']).to.eql(buildSystem.expectedDefaultGenerator);
            expect(context.testEnv.errorMessagesQueue.length)
-               .to.be.eq(0, 'Wrong message ' + context.testEnv.errorMessagesQueue[0]);
+               .to.eql(0, 'Wrong message ' + context.testEnv.errorMessagesQueue[0]);
          });
   });
 });

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -74,9 +74,8 @@ const DEFAULT_MINGW_KITS: KitEnvironment[] = [
 const DEFAULT_WINDOWS_KITS: KitEnvironment[] = DEFAULT_VS_KITS.concat(DEFAULT_CYGWIN_KITS, DEFAULT_MINGW_KITS);
 
 const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
-  ['win32']: DEFAULT_WINDOWS_KITS.concat([
-    {defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
-  ]),
+  ['win32']: DEFAULT_WINDOWS_KITS.concat(
+      [{defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}]),
   ['Visual Studio 2017']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2017 Preview']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2015']: DEFAULT_WINDOWS_KITS,

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -19,7 +19,7 @@ if (workername === undefined) {
   workername = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'osx' : 'linux';
 }
 
-const VISUAL_STUDIO_KITS: KitEnvironment[] = [
+const DEFAULT_VS_KITS: KitEnvironment[] = [
   // Visual Studio 2017
   {
     defaultKit: 'Visual Studio Community 2017',
@@ -54,41 +54,33 @@ const VISUAL_STUDIO_KITS: KitEnvironment[] = [
   {defaultKit: 'VisualStudio.11.0', expectedDefaultGenerator: 'Visual Studio 11 2012', path: ['']},
 ];
 
+const DEFAULT_CYGWIN_KITS: KitEnvironment[] = [
+  {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']},
+  {defaultKit: 'Clang 4.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']},
+  {defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
+];
+
+const DEFAULT_MINGW_KITS: KitEnvironment[] = [
+  {
+    defaultKit: 'GCC 7.2.0',
+    expectedDefaultGenerator: 'MinGW Makefiles',
+    path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+  },
+  {
+    defaultKit: 'GCC 6.3.0',
+    expectedDefaultGenerator: 'MinGW Makefiles',
+    path: ['C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+  },
+  {defaultKit: 'GCC 5.3.0', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']}
+];
+
+const DEFAULT_WINDOWS_KITS: KitEnvironment[] = DEFAULT_VS_KITS.concat(DEFAULT_CYGWIN_KITS, DEFAULT_MINGW_KITS);
+
 const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
-  ['windows']: VISUAL_STUDIO_KITS.concat([
-    {
-      defaultKit: 'GCC 7.2.0',
-      expectedDefaultGenerator: 'MinGW Makefiles',
-      path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-    },
-    {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']},
-    {defaultKit: 'Clang 4.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']},
-    {defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
-  ]),
-  ['Visual Studio 2017']: VISUAL_STUDIO_KITS.concat([
-    {
-      defaultKit: 'GCC 7.2.0',
-      expectedDefaultGenerator: 'MinGW Makefiles',
-      path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-    },
-    {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
-  ]),
-  ['Visual Studio 2017 Preview']: VISUAL_STUDIO_KITS.concat(
-      [{defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}]),
-  ['Visual Studio 2015']: VISUAL_STUDIO_KITS.concat([
-    {
-      defaultKit: 'GCC 7.2.0',
-      expectedDefaultGenerator: 'MinGW Makefiles',
-      path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-    },
-    {
-      defaultKit: 'GCC 6.3.0',
-      expectedDefaultGenerator: 'MinGW Makefiles',
-      path: ['C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-    },
-    {defaultKit: 'GCC 5.3.0', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']},
-    {defaultKit: 'GCC 6.4.0', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}
-  ]),
+  ['windows']: DEFAULT_WINDOWS_KITS,
+  ['Visual Studio 2017']: DEFAULT_WINDOWS_KITS,
+  ['Visual Studio 2017 Preview']: DEFAULT_WINDOWS_KITS,
+  ['Visual Studio 2015']: DEFAULT_WINDOWS_KITS,
   ['linux']: [
     {defaultKit: 'Clang', expectedDefaultGenerator: 'Unix Makefiles'},
     {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles'}

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -24,27 +24,34 @@ const VISUAL_STUDIO_KITS: KitEnvironment[] = [
   {
     defaultKit: 'Visual Studio Community 2017',
     excludeKit: 'Preview',
-    expectedDefaultGenerator: 'Visual Studio 15 2017'
+    expectedDefaultGenerator: 'Visual Studio 15 2017',
+    path: ['']
   },
-  {defaultKit: 'Visual Studio Community 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {defaultKit: 'Visual Studio Community 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017', path: ['']},
   {
     defaultKit: 'Visual Studio Professional 2017',
     excludeKit: 'Preview',
-    expectedDefaultGenerator: 'Visual Studio 15 2017'
+    expectedDefaultGenerator: 'Visual Studio 15 2017',
+    path: ['']
   },
-  {defaultKit: 'Visual Studio Professional 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {
+    defaultKit: 'Visual Studio Professional 2017 Preview',
+    expectedDefaultGenerator: 'Visual Studio 15 2017',
+    path: ['']
+  },
   {
     defaultKit: 'Visual Studio Enterprise 2017',
     excludeKit: 'Preview',
-    expectedDefaultGenerator: 'Visual Studio 15 2017'
+    expectedDefaultGenerator: 'Visual Studio 15 2017',
+    path: ['']
   },
-  {defaultKit: 'Visual Studio Enterprise 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {defaultKit: 'Visual Studio Enterprise 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017', path: ['']},
 
   // Visual Studio 2015
-  {defaultKit: 'VisualStudio.14.0', expectedDefaultGenerator: 'Visual Studio 14 2015'},
+  {defaultKit: 'VisualStudio.14.0', expectedDefaultGenerator: 'Visual Studio 14 2015', path: ['']},
 
   // Visual Studio 2012
-  {defaultKit: 'VisualStudio.11.0', expectedDefaultGenerator: 'Visual Studio 11 2012'},
+  {defaultKit: 'VisualStudio.11.0', expectedDefaultGenerator: 'Visual Studio 11 2012', path: ['']},
 ];
 
 const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
@@ -237,11 +244,6 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
            skipTestIf({preferredGeneratorIsAvailable: true}, this, context);
            this.timeout(BUILD_TIMEOUT);
 
-           // We need to clear the path for cygwin installations, else CMake will
-           // complain about sh.exe being present.
-           if (context.buildSystem.path && context.buildSystem.path[0].includes('cygwin'))
-             process.env.PATH = '';
-
            await context.cmt.selectKit();
            await context.testEnv.setting.changeSetting('preferredGenerators', ['BlaBla']);
            await expect(context.cmt.build()).to.eventually.be.rejected;
@@ -256,11 +258,6 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
            skipTestIf({preferredGeneratorIsAvailable: true}, this, context);
            this.timeout(BUILD_TIMEOUT);
 
-           // We need to clear the path for cygwin installations, else CMake will
-           // complain about sh.exe being present.
-           if (context.buildSystem.path && context.buildSystem.path[0].includes('cygwin'))
-             process.env.PATH = '';
-
            await context.cmt.selectKit();
            await context.testEnv.setting.changeSetting('preferredGenerators', []);
            await expect(context.cmt.build()).to.eventually.be.rejected;
@@ -270,15 +267,9 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
                .to.be.contains('Unable to determine what CMake generator to use.');
          });
 
-    test(`Use preferred generator from settings.json (${buildSystem.defaultKit})`,
+    test(`Use preferred generator from settings or kit file (${buildSystem.defaultKit})`,
          async function(this: ITestCallbackContext) {
            this.timeout(BUILD_TIMEOUT);
-
-           // We need to clear the path for cygwin installations, else CMake will
-           // complain about sh.exe being present.
-           if (context.buildSystem.path && context.buildSystem.path[0].includes('cygwin')) {
-             process.env.PATH = '';
-           }
 
            await context.cmt.selectKit();
            await context.testEnv.setting.changeSetting('preferredGenerators', ['Unix Makefiles', 'MinGW Makefiles']);

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -15,64 +15,45 @@ if (process.env.TRAVIS_OS_NAME) {
 }
 
 if (workername === undefined) {
-  workername = process.platform == 'win32' ? 'DevPC' : 'linux';
+  workername = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'osx' : 'linux';
 }
 
-const KITS_BY_PLATFORM: {[os: string]: KitEnvironment[]} = {
-  ['DevPC']: [
-    {defaultKit: 'Visual Studio Community 2017', expectedDefaultGenerator: 'Visual Studio 15 2017', path: ['c:\\Temp']},
-    {
-      defaultKit: 'Visual Studio Community 2017 Preview',
-      expectedDefaultGenerator: 'Visual Studio 15 2017',
-      path: ['c:\\Temp']
-    },
-    {
-      defaultKit: 'Visual Studio Professional 2017',
-      expectedDefaultGenerator: 'Visual Studio 15 2017',
-      path: ['c:\\Temp']
-    },
-    {
-      defaultKit: 'Visual Studio Professional 2017 Preview',
-      expectedDefaultGenerator: 'Visual Studio 15 2017',
-      path: ['c:\\Temp']
-    },
-    {
-      defaultKit: 'Visual Studio Enterprise 2017',
-      expectedDefaultGenerator: 'Visual Studio 15 2017',
-      path: ['c:\\Temp']
-    },
-    {
-      defaultKit: 'Visual Studio Enterprise 2017 Preview',
-      expectedDefaultGenerator: 'Visual Studio 15 2017',
-      path: ['c:\\Temp']
-    },
-    {defaultKit: 'VisualStudio.14.0', expectedDefaultGenerator: 'Visual Studio 14 2015', path: ['c:\\Temp']},
-    {
-      defaultKit: 'GCC',
-      expectedDefaultGenerator: 'MinGW Makefiles',
-      path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-    }
-  ],
-  ['Visual Studio 2017']: [
-    {defaultKit: 'Visual Studio Community 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'},
-    {
-      defaultKit: 'GCC',
-      expectedDefaultGenerator: 'MinGW Makefiles',
-      path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-    }
-  ],
-  ['Visual Studio 2017 Preview']:
-      [{defaultKit: 'Visual Studio Community 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'}],
-  ['Visual Studio 2015']: [
-    {defaultKit: 'VisualStudio.14.0', expectedDefaultGenerator: 'Visual Studio 14 2015'},
-    {defaultKit: 'VisualStudio.11.0', expectedDefaultGenerator: 'Visual Studio 11 2012'},
+const VISUAL_STUDIO_KITS: KitEnvironment[] = [
+  // Visual Studio 2017
+  {defaultKit: 'Visual Studio Community 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {defaultKit: 'Visual Studio Community 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {defaultKit: 'Visual Studio Professional 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {defaultKit: 'Visual Studio Professional 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {defaultKit: 'Visual Studio Enterprise 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+  {defaultKit: 'Visual Studio Enterprise 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'},
+
+  // Visual Studio 2015
+  {defaultKit: 'VisualStudio.14.0', expectedDefaultGenerator: 'Visual Studio 14 2015'},
+
+  // Visual Studio 2012
+  {defaultKit: 'VisualStudio.11.0', expectedDefaultGenerator: 'Visual Studio 11 2012'},
+];
+
+const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
+  ['windows']: VISUAL_STUDIO_KITS.concat([{
+    defaultKit: 'GCC',
+    expectedDefaultGenerator: 'MinGW Makefiles',
+    path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+  }]),
+  ['Visual Studio 2017']: VISUAL_STUDIO_KITS.concat([{
+    defaultKit: 'GCC',
+    expectedDefaultGenerator: 'MinGW Makefiles',
+    path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+  }]),
+  ['Visual Studio 2017 Preview']: VISUAL_STUDIO_KITS.concat([]),
+  ['Visual Studio 2015']: VISUAL_STUDIO_KITS.concat([
     {
       defaultKit: 'GCC',
       expectedDefaultGenerator: 'MinGW Makefiles',
       path: ['C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
     },
     {defaultKit: 'GCC', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']}
-  ],
+  ]),
   ['linux']: [
     {defaultKit: 'Clang', expectedDefaultGenerator: 'Unix Makefiles'},
     {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles'}

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -37,7 +37,7 @@ const KITS_BY_PLATFORM: {[os: string]: KitEnvironment[]} = {
     }
   ],
   ['Visual Studio 2017 Preview']:
-      [{defaultKit: 'Visual Studio Community 2017', expectedDefaultGenerator: 'Visual Studio 15 2017'}],
+      [{defaultKit: 'Visual Studio Community 2017 Preview', expectedDefaultGenerator: 'Visual Studio 15 2017'}],
   ['Visual Studio 2015']: [
     {defaultKit: 'VisualStudio.14.0', expectedDefaultGenerator: 'Visual Studio 14 2015'},
     {defaultKit: 'VisualStudio.11.0', expectedDefaultGenerator: 'Visual Studio 11 2012'},
@@ -70,19 +70,19 @@ interface CMakeContext {
   buildSystem: KitEnvironment;
 }
 
-function isPreferedGeneratorInKit(defaultKit: string): boolean {
+function isPreferredGeneratorInKit(defaultKit: string): boolean {
   return RegExp('^Visual[ ]{0,1}Studio').test(defaultKit);
 }
 
 function skipTestWithoutPreferredGeneratorInKit(testContext: any, context: CMakeContext): void {
-  if (!isPreferedGeneratorInKit(context.buildSystem.defaultKit)) {
+  if (!isPreferredGeneratorInKit(context.buildSystem.defaultKit)) {
     testContext.skip();
   }
 }
 
-// Needed by test "Non preferred generators configured in settings and kit"
+// Needed by test "No preferred generators configured in settings and kit"
 function skipTestWithPreferredGeneratorInKit(testContext: any, context: CMakeContext): void {
-  if (isPreferedGeneratorInKit(context.buildSystem.defaultKit)) {
+  if (isPreferredGeneratorInKit(context.buildSystem.defaultKit)) {
     testContext.skip();
   }
 }
@@ -138,11 +138,11 @@ function makeExtensionTestSuite(name: string,
 }
 
 KITS_BY_PLATFORM[workername].forEach(buildSystem => {
-  makeExtensionTestSuite(`Prefered generators (${buildSystem.defaultKit})`, buildSystem, (context: CMakeContext) => {
+  makeExtensionTestSuite(`Preferred generators (${buildSystem.defaultKit})`, buildSystem, (context: CMakeContext) => {
     const BUILD_TIMEOUT: number = 120000;
 
     // Test only one visual studio, because there is only a preferred generator in kit by default
-    // Prefered generator selection order is settings.json -> cmake-kit.json -> error
+    // Preferred generator selection order is settings.json -> cmake-kit.json -> error
     test('Use preferred generator from kit file', async function(this: ITestCallbackContext) {
       skipTestWithoutPreferredGeneratorInKit(this, context);
       this.timeout(BUILD_TIMEOUT);
@@ -179,7 +179,7 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
       expect(context.testEnv.errorMessagesQueue[0]).to.be.contains('Unable to determine what CMake generator to use.');
     });
 
-    test('Non preferred generators configured in settings and kit', async function(this: ITestCallbackContext) {
+    test('No preferred generators configured in settings and kit', async function(this: ITestCallbackContext) {
       skipTestWithPreferredGeneratorInKit(this, context);
       this.timeout(BUILD_TIMEOUT);
       await context.cmt.selectKit();

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -16,7 +16,7 @@ if (process.env.TRAVIS_OS_NAME) {
 }
 
 if (workername === undefined) {
-  workername = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'osx' : 'linux';
+  workername = process.platform;
 }
 
 const DEFAULT_VS_KITS: KitEnvironment[] = [
@@ -75,7 +75,7 @@ const DEFAULT_MINGW_KITS: KitEnvironment[] = [
 const DEFAULT_WINDOWS_KITS: KitEnvironment[] = DEFAULT_VS_KITS.concat(DEFAULT_CYGWIN_KITS, DEFAULT_MINGW_KITS);
 
 const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
-  ['windows']: DEFAULT_WINDOWS_KITS,
+  ['win32']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2017']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2017 Preview']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2015']: DEFAULT_WINDOWS_KITS,
@@ -83,6 +83,11 @@ const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
     {defaultKit: 'Clang', expectedDefaultGenerator: 'Unix Makefiles'},
     {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles'}
   ],
+  ['darwin']: [
+    {defaultKit: 'Clang', expectedDefaultGenerator: 'Unix Makefiles'},
+    {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles'}
+  ],
+  // This is a special case for travis
   ['osx']: [{
     defaultKit: 'Clang',
     expectedDefaultGenerator: 'Unix Makefiles',

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -199,7 +199,7 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
 
     // Test only one visual studio, because there is only a preferred generator in kit by default
     // Preferred generator selection order is settings.json -> cmake-kit.json -> error
-    test('Use preferred generator from kit file', async function(this: ITestCallbackContext) {
+    test(`Use preferred generator from kit file (${buildSystem.defaultKit})`, async function(this: ITestCallbackContext) {
       skipTestIf({preferredGeneratorIsNotAvailable: true, kitIsNotAvailable: true}, this, context);
       this.timeout(BUILD_TIMEOUT);
 
@@ -211,7 +211,7 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
       expect(context.testEnv.errorMessagesQueue.length).to.be.eq(0);
     });
 
-    test('Use preferred generator from settings file', async function(this: ITestCallbackContext) {
+    test(`Use preferred generator from settings file (${buildSystem.defaultKit})`, async function(this: ITestCallbackContext) {
       skipTestIf({preferredGeneratorIsNotAvailable: true, kitIsNotAvailable: true}, this, context);
       this.timeout(BUILD_TIMEOUT);
 
@@ -224,7 +224,7 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
       expect(context.testEnv.errorMessagesQueue.length).to.be.eq(0);
     });
 
-    test('Reject invalid preferred generator in settings file', async function(this: ITestCallbackContext) {
+    test(`Reject invalid preferred generator in settings file (${buildSystem.defaultKit})`, async function(this: ITestCallbackContext) {
       skipTestIf({preferredGeneratorIsAvailable: true, kitIsNotAvailable: true}, this, context);
       this.timeout(BUILD_TIMEOUT);
 
@@ -236,7 +236,7 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
       expect(context.testEnv.errorMessagesQueue[0]).to.be.contains('Unable to determine what CMake generator to use.');
     });
 
-    test('Reject if all \'preferredGenerators\' fields are empty', async function(this: ITestCallbackContext) {
+    test(`Reject if all \'preferredGenerators\' fields are empty (${buildSystem.defaultKit})`, async function(this: ITestCallbackContext) {
       skipTestIf({preferredGeneratorIsAvailable: true, kitIsNotAvailable: true}, this, context);
       this.timeout(BUILD_TIMEOUT);
 
@@ -248,7 +248,7 @@ KITS_BY_PLATFORM[workername].forEach(buildSystem => {
       expect(context.testEnv.errorMessagesQueue[0]).to.be.contains('Unable to determine what CMake generator to use.');
     });
 
-    test('Use preferred generator from settings.json', async function(this: ITestCallbackContext) {
+    test(`Use preferred generator from settings.json (${buildSystem.defaultKit})`, async function(this: ITestCallbackContext) {
       skipTestIf({kitIsNotAvailable: true}, this, context);
       this.timeout(BUILD_TIMEOUT);
 

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -40,19 +40,29 @@ const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
     expectedDefaultGenerator: 'MinGW Makefiles',
     path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
   }]),
-  ['Visual Studio 2017']: VISUAL_STUDIO_KITS.concat([{
-    defaultKit: 'GCC',
-    expectedDefaultGenerator: 'MinGW Makefiles',
-    path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
-  }]),
-  ['Visual Studio 2017 Preview']: VISUAL_STUDIO_KITS.concat([]),
+  ['Visual Studio 2017']: VISUAL_STUDIO_KITS.concat([
+    {
+      defaultKit: 'GCC',
+      expectedDefaultGenerator: 'MinGW Makefiles',
+      path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+    },
+    {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles', path: ['C:\\cygwin64\\bin']}
+  ]),
+  ['Visual Studio 2017 Preview']: VISUAL_STUDIO_KITS.concat(
+      [{defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles', path: ['C:\\cygwin64\\bin']}]),
   ['Visual Studio 2015']: VISUAL_STUDIO_KITS.concat([
+    {
+      defaultKit: 'GCC',
+      expectedDefaultGenerator: 'MinGW Makefiles',
+      path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+    },
     {
       defaultKit: 'GCC',
       expectedDefaultGenerator: 'MinGW Makefiles',
       path: ['C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
     },
-    {defaultKit: 'GCC', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']}
+    {defaultKit: 'GCC', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']},
+    {defaultKit: 'GCC', expectedDefaultGenerator: 'Unix Makefiles', path: ['C:\\cygwin64\\bin']}
   ]),
   ['linux']: [
     {defaultKit: 'Clang', expectedDefaultGenerator: 'Unix Makefiles'},

--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -24,13 +24,6 @@ export class DefaultEnvironment {
     this.projectFolder = new ProjectRootHelper(projectRoot, buildLocation);
     this.result = new TestProgramResult(this.projectFolder.buildDirectory.location, executableResult);
 
-    if (!defaultKitLabel) {
-      if (process.platform == 'win32') {
-        defaultKitLabel = 'Visual';
-      } else {
-        defaultKitLabel = ' ';
-      }
-    }
     this.kitSelection = new SelectKitPickerHandle(defaultKitLabel, excludeKitLabel);
     this.setupShowQuickPickerStub([this.kitSelection]);
 

--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -16,18 +16,22 @@ export class DefaultEnvironment {
   setting: CMakeToolsSettingFile;
   errorMessagesQueue: string[] = [];
 
-  public constructor(projectRoot: string, buildLocation: string, executableResult: string, defaultkitRegExp?: string) {
+  public constructor(projectRoot: string,
+                     buildLocation: string,
+                     executableResult: string,
+                     defaultKitLabel?: string,
+                     excludeKitLabel?: string) {
     this.projectFolder = new ProjectRootHelper(projectRoot, buildLocation);
     this.result = new TestProgramResult(this.projectFolder.buildDirectory.location, executableResult);
 
-    if (!defaultkitRegExp) {
+    if (!defaultKitLabel) {
       if (process.platform == 'win32') {
-        defaultkitRegExp = '^Visual ?Studio';
+        defaultKitLabel = 'Visual';
       } else {
-        defaultkitRegExp = '.';
+        defaultKitLabel = ' ';
       }
     }
-    this.kitSelection = new SelectKitPickerHandle(defaultkitRegExp);
+    this.kitSelection = new SelectKitPickerHandle(defaultKitLabel, excludeKitLabel);
     this.setupShowQuickPickerStub([this.kitSelection]);
 
     this.setting = new CMakeToolsSettingFile(this.sandbox);

--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -24,6 +24,8 @@ export class DefaultEnvironment {
     this.projectFolder = new ProjectRootHelper(projectRoot, buildLocation);
     this.result = new TestProgramResult(this.projectFolder.buildDirectory.location, executableResult);
 
+    if (!defaultKitLabel)
+      defaultKitLabel = '';
     this.kitSelection = new SelectKitPickerHandle(defaultKitLabel, excludeKitLabel);
     this.setupShowQuickPickerStub([this.kitSelection]);
 

--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -24,8 +24,10 @@ export class DefaultEnvironment {
     this.projectFolder = new ProjectRootHelper(projectRoot, buildLocation);
     this.result = new TestProgramResult(this.projectFolder.buildDirectory.location, executableResult);
 
-    if (!defaultKitLabel)
-      defaultKitLabel = '';
+    if (!defaultKitLabel) {
+      defaultKitLabel = process.platform === 'win32' ? 'Visual' : '';
+    }
+
     this.kitSelection = new SelectKitPickerHandle(defaultKitLabel, excludeKitLabel);
     this.setupShowQuickPickerStub([this.kitSelection]);
 

--- a/test/helpers/vscodefake/quick-picker.ts
+++ b/test/helpers/vscodefake/quick-picker.ts
@@ -8,25 +8,20 @@ export interface QuickPickerHandleStrategy {
 
 export class SelectKitPickerHandle implements QuickPickerHandleStrategy {
 
-  constructor(readonly defaultKitLabel?: string, readonly excludeKitLabel?: string) {}
+  constructor(readonly defaultKitLabel: string, readonly excludeKitLabel?: string) {}
 
   public get identifier(): string { return 'Select a Kit'; }
 
   public handleQuickPick(items: any): any {
-    if (!this.defaultKitLabel || this.defaultKitLabel === '') {
-      return Promise.resolve(items[0]);
-    }
-
-    const defaultKitLabel = this.defaultKitLabel;
     let defaultKit: string[]|undefined = items.filter((item: any) => {
       const name: string = item.label;
-      return name ? (name === defaultKitLabel ? item : undefined) : undefined;
+      return name ? (name === this.defaultKitLabel ? item : undefined) : undefined;
     });
 
     if (!defaultKit || defaultKit.length === 0) {
       defaultKit = items.filter((item: any) => {
         const name: string = item.label;
-        return name ? (name.includes(defaultKitLabel)
+        return name ? (name.includes(this.defaultKitLabel)
                                && (this.excludeKitLabel ? !name.includes(this.excludeKitLabel) : true)
                            ? item
                            : undefined)

--- a/test/helpers/vscodefake/quick-picker.ts
+++ b/test/helpers/vscodefake/quick-picker.ts
@@ -8,7 +8,7 @@ export interface QuickPickerHandleStrategy {
 
 export class SelectKitPickerHandle implements QuickPickerHandleStrategy {
 
-  constructor(readonly defaultKitLabelRegEx: string) {}
+  constructor(readonly defaultKitLabel: string, readonly excludeKitLabel?: string) {}
 
   public get identifier(): string { return 'Select a Kit'; }
 
@@ -16,7 +16,8 @@ export class SelectKitPickerHandle implements QuickPickerHandleStrategy {
     const defaultKit: string[] = items.filter((item: any) => {
       const name: string = item.label;
       if (name) {
-        if (new RegExp(this.defaultKitLabelRegEx).test(name)) {
+        if (name.includes(this.defaultKitLabel)
+            && (this.excludeKitLabel ? !name.includes(this.excludeKitLabel) : true)) {
           return item;
         }
       } else {

--- a/test/helpers/vscodefake/quick-picker.ts
+++ b/test/helpers/vscodefake/quick-picker.ts
@@ -13,17 +13,22 @@ export class SelectKitPickerHandle implements QuickPickerHandleStrategy {
   public get identifier(): string { return 'Select a Kit'; }
 
   public handleQuickPick(items: any): any {
-    const defaultKit: string[] = items.filter((item: any) => {
+    let defaultKit: string[]|undefined = items.filter((item: any) => {
       const name: string = item.label;
-      if (name) {
-        if (name.includes(this.defaultKitLabel)
-            && (this.excludeKitLabel ? !name.includes(this.excludeKitLabel) : true)) {
-          return item;
-        }
-      } else {
-        return;
-      }
+      return name ? (name === this.defaultKitLabel ? item : undefined) : undefined;
     });
+
+    if (!defaultKit || defaultKit.length === 0) {
+      defaultKit = items.filter((item: any) => {
+        const name: string = item.label;
+        return name ? (name.includes(this.defaultKitLabel)
+                               && (this.excludeKitLabel ? !name.includes(this.excludeKitLabel) : true)
+                           ? item
+                           : undefined)
+                    : undefined;
+      });
+    }
+
     if (defaultKit && defaultKit.length != 0) {
       return Promise.resolve(defaultKit[0]);
     } else {

--- a/test/helpers/vscodefake/quick-picker.ts
+++ b/test/helpers/vscodefake/quick-picker.ts
@@ -8,20 +8,25 @@ export interface QuickPickerHandleStrategy {
 
 export class SelectKitPickerHandle implements QuickPickerHandleStrategy {
 
-  constructor(readonly defaultKitLabel: string, readonly excludeKitLabel?: string) {}
+  constructor(readonly defaultKitLabel?: string, readonly excludeKitLabel?: string) {}
 
   public get identifier(): string { return 'Select a Kit'; }
 
   public handleQuickPick(items: any): any {
+    if (!this.defaultKitLabel || this.defaultKitLabel === '') {
+      return Promise.resolve(items[0]);
+    }
+
+    const defaultKitLabel = this.defaultKitLabel;
     let defaultKit: string[]|undefined = items.filter((item: any) => {
       const name: string = item.label;
-      return name ? (name === this.defaultKitLabel ? item : undefined) : undefined;
+      return name ? (name === defaultKitLabel ? item : undefined) : undefined;
     });
 
     if (!defaultKit || defaultKit.length === 0) {
       defaultKit = items.filter((item: any) => {
         const name: string = item.label;
-        return name ? (name.includes(this.defaultKitLabel)
+        return name ? (name.includes(defaultKitLabel)
                                && (this.excludeKitLabel ? !name.includes(this.excludeKitLabel) : true)
                            ? item
                            : undefined)


### PR DESCRIPTION
## Related Issues
Fixes #220.

## Changes
This PR tries to fix the vswhere utf8 bug, where the JSON parser throws because of encoding/code page issues. The method I used is the one mentioned by heaths in the issue above.
I added a separate function that uses `execFile()` instead of `spawn()` in the hope that it fixes the issues other users encountered. Sadly, I couldn't really verify whether this fixes the problem at hand though.

The other thing that this PR does is to differentiate between release and pre-release versions of Visual Studio. For pre-release versions, the `Preview` identifier is appended to the display name.
Since I don't have the **Community** edition of VS installed, but the **Professional** one, pretty much all the `preferred-generators` tests failed. I fixed this by getting the known kits from the extension (I had to add a getter for that) and checking whether the default kit name in question is present. I redid the check for preferred generators the same way, instead of using a regex.