### PR TITLE
Move var expansion into a dedicated module

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -165,38 +165,6 @@ export abstract class CMakeDriver implements vscode.Disposable {
   }
 
   /**
-   * Get replacements from the state manager and update driver relevant
-   * ones.
-   */
-  private get _replacements(): {[key: string]: string|undefined} {
-    const ws_root = util.normalizePath(vscode.workspace.rootPath || '.');
-    const user_dir = process.platform === 'win32' ? process.env['HOMEPATH']! : process.env['HOME']!;
-    const replacements: {[key: string]: string|undefined} = {};
-
-    // Update default replacements
-    replacements['workspaceRoot'] = vscode.workspace.rootPath;
-    replacements['buildType'] = this.currentBuildType;
-    replacements['workspaceRootFolderName'] = path.basename(ws_root);
-    replacements['generator'] = this.generatorName || 'null';
-    replacements['projectName'] = this.projectName;
-    replacements['userHome'] = user_dir;
-
-    // Update Variant replacements
-    const variantSettings = this.stateManager.activeVariantSettings;
-    if (variantSettings) {
-      variantSettings.forEach((value: string, key: string) => {
-        if (key != 'buildType') {
-          replacements[key] = value;
-        } else {
-          replacements['buildLabel'] = value;
-        }
-      });
-    }
-
-    return replacements;
-  }
-
-  /**
    * Get the environment and apply any needed
    * substitutions before returning it.
    */

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -1,0 +1,113 @@
+/**
+ * Module for working with and performing expansion of template strings
+ * with `${var}`-style variable template expressions.
+ */
+
+import * as vscode from 'vscode';
+
+import {createLogger} from './logging';
+import {EnvironmentVariables} from './proc';
+import {normalizeEnvironmentVarname, replaceAll} from './util';
+
+const log = createLogger('expand');
+
+/**
+ * The required keys for expanding a string in CMake Tools.
+ *
+ * Unless otherwise specified, CMake Tools guarantees that certain variable
+ * references will be available when performing an expansion. Those guaranteed
+ * variables are specified as properties on this interface.
+ */
+export interface RequiredExpansionContextVars {
+  workspaceRoot: string;
+  buildType: string;
+  workspaceRootFolderName: string;
+  generator: string;
+  projectName: string;
+  userHome: string;
+}
+
+/**
+ * Key-value type for variable expansions
+ */
+export interface ExpansionVars extends RequiredExpansionContextVars { [key: string]: string; }
+
+/**
+ * Options to control the behavior of `expandString`.
+ */
+export interface ExpansionOptions {
+  /**
+   * Plain `${variable}` style expansions.
+   */
+  vars: ExpansionVars;
+  /**
+   * Override the values used in `${env:var}`-style expansions.
+   *
+   * Note that setting this property will disable expansion of environment
+   * variables for the running process. Only environment variables in this key
+   * will be expanded.
+   */
+  envOverride?: EnvironmentVariables;
+}
+
+/**
+ * Replace ${variable} references in the given string with their corresponding
+ * values.
+ * @param instr The input string
+ * @param opts Options for the expansion process
+ * @returns A string with the variable references replaced
+ */
+export async function expandString(tmpl: string, opts: ExpansionOptions) {
+  const env = opts.envOverride ? opts.envOverride : process.env;
+  const repls = opts.vars;
+
+  // We accumulate a list of substitutions that we need to make, preventing
+  // recursively expanding or looping forever on bad replacements
+  const subs = new Map<string, string>();
+
+  const var_re = /\$\{(\w+)\}/g;
+  let mat: RegExpMatchArray|null = null;
+  while ((mat = var_re.exec(tmpl))) {
+    const full = mat[0];
+    const key = mat[1];
+    const repl = repls[key];
+    if (!repl) {
+      log.warning(`Invalid variable reference ${full} in string: ${tmpl}`);
+    } else {
+      subs.set(full, repl);
+    }
+  }
+
+  const env_re = /\$\{env:(.+?)\}/g;
+  while ((mat = env_re.exec(tmpl))) {
+    const full = mat[0];
+    const varname = mat[1];
+    const repl = env[normalizeEnvironmentVarname(varname)] || '';
+    subs.set(full, repl);
+  }
+
+  const env2_re = /\$\{env\.(.+?)\}/g;
+  while ((mat = env2_re.exec(tmpl))) {
+    const full = mat[0];
+    const varname = mat[1];
+    const repl = env[normalizeEnvironmentVarname(varname)] || '';
+    subs.set(full, repl);
+  }
+
+  const command_re = /\$\{command:(.+?)\}/g;
+  while ((mat = command_re.exec(tmpl))) {
+    const full = mat[0];
+    const command = mat[1];
+    if (subs.has(full)) {
+      continue;  // Don't execute commands more than once per string
+    }
+    try {
+      const command_ret = await vscode.commands.executeCommand(command);
+      subs.set(full, `${command_ret}`);
+    } catch (e) { log.warning(`Exception while executing command ${command} for string: ${tmpl} (${e})`); }
+  }
+
+  let final_str = tmpl;
+  subs.forEach((value, key) => { final_str = replaceAll(final_str, key, value); });
+  return final_str;
+}

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -149,7 +149,7 @@ export class VariantManager implements vscode.Disposable {
         if (filepath.endsWith('.json')) {
           new_variants = json5.parse(content);
         } else {
-          new_variants = yaml.load(content);
+          new_variants = yaml.load(content) as VariantFileContent;
         }
       } catch (e) { log.error(`Error parsing ${filepath}: ${e}`); }
     }


### PR DESCRIPTION
## This change addresses testing and modularity

### This changes the scope in which variables are expanded

The following changes are proposed:

- Move `expandString` to a separate module.
- Pass the expansion options along with the string, facilitating testing
- Allow overriding of environment variables to expand strings in a different environment.

## The purpose of this change

Need to untangle different aspects of the extension, so I thought I'd start small with variable expansion, something that recently got a lot of additional features and was tied closely to the other components.

By stripping the expansions to a separate location, we can now do expansions in different contexts from the CMake driver, as well as test it in isolation.

## Other Notes/Information

@ytimenkov, this is just to get started small on the modularization changes I'm hoping to get, along with your more ambitious proposals.

With the new testing infrastructure in place, I'm feeling a lot more confident about making changes like these. Thanks all!

I'm planning to write some tests for expansion that run outside the context of a driver, but I'm too tired right now. I'll be back. (Wed Mar 28 06:20:37 UTC 2018)