### PR TITLE
[beta5] Merge duplicate MinGW kits into one kit

### DIFF
--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -56,27 +56,26 @@ const DEFAULT_MINGW_KITS: KitEnvironment[] = [
   {
     defaultKit: 'GCC 7.3.0',
     expectedDefaultGenerator: 'MinGW Makefiles',
-    path: ['C:\\Program Files\\mingw-w64\\x86_64-7.3.0-posix-seh-rt_v5-rev0\\mingw64\\bin']
-  },
-  {
-    defaultKit: 'GCC 7.3.0',
-    expectedDefaultGenerator: 'MinGW Makefiles',
-    path: ['C:\\mingw-w64\\x86_64-7.3.0-posix-seh-rt_v5-rev0\\mingw64\\bin']
-  },
-  {
-    defaultKit: 'GCC 7.2.0',
-    expectedDefaultGenerator: 'MinGW Makefiles',
-    path: ['C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+    path: [
+      'C:\\Program Files\\mingw-w64\\x86_64-7.3.0-posix-seh-rt_v5-rev0\\mingw64\\bin',
+      'C:\\mingw-w64\\x86_64-7.3.0-posix-seh-rt_v5-rev0\\mingw64\\bin'
+    ]
   },
   {
     defaultKit: 'GCC 7.2.0',
     expectedDefaultGenerator: 'MinGW Makefiles',
-    path: ['C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+    path: [
+      'C:\\Program Files\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin',
+      'C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin'
+    ]
   },
   {
     defaultKit: 'GCC 6.3.0',
     expectedDefaultGenerator: 'MinGW Makefiles',
-    path: ['C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin']
+    path: [
+      'C:\\Program Files\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin',
+      'C:\\mingw-w64\\x86_64-6.3.0-posix-seh-rt_v5-rev1\\mingw64\\bin'
+    ]
   },
   {defaultKit: 'GCC 5.3.0', expectedDefaultGenerator: 'MinGW Makefiles', path: ['C:\\MinGW\\bin']}
 ];


### PR DESCRIPTION
This PR just merges duplicate MinGW kits in the preferred-generators test into one kit.