### PR TITLE
Refactor/quickstart

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -59,7 +59,7 @@ if (! $NoTest) {
         -TestsPath "$REPO_DIR/out/test/unit-tests" `
         -Workspace "$REPO_DIR/test/unit-tests/test-project-without-cmakelists"
 
-    foreach ($name in @("successful-build"; "without-cmakelist-file"; )) {
+    foreach ($name in @("vs-preferred-gen"; "successful-build"; "without-cmakelist-file"; )) {
         Invoke-VSCodeTest "CMake Tools: $name" `
             -TestsPath "$REPO_DIR/out/test/extension-tests/$name" `
             -Workspace "$REPO_DIR/test/extension-tests/$name/project-folder"

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -59,7 +59,7 @@ if (! $NoTest) {
         -TestsPath "$REPO_DIR/out/test/unit-tests" `
         -Workspace "$REPO_DIR/test/unit-tests/test-project-without-cmakelists"
 
-    foreach ($name in @("successful-build"; )) {
+    foreach ($name in @("successful-build"; "without-cmakelist-file"; )) {
         Invoke-VSCodeTest "CMake Tools: $name" `
             -TestsPath "$REPO_DIR/out/test/extension-tests/$name" `
             -Workspace "$REPO_DIR/test/extension-tests/$name/project-folder"

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -21,7 +21,7 @@ import {NagManager} from './nag';
 import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
-import {QuickStartCallbacks, quickstartWorkflow} from './quickstart';
+import * as quickStart from './quickstart';
 import rollbar from './rollbar';
 import {StateManager} from './state';
 import {StatusBar} from './status';
@@ -789,8 +789,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         ? []
         : (vscode.workspace.workspaceFolders!).map(item => item.uri.fsPath);
 
-    const callbacks: QuickStartCallbacks = {
+    const callbacks: quickStart.UiControlCallbacks = {
       onError: message => { vscode.window.showErrorMessage(message); },
+      onWarning: message => { vscode.window.showWarningMessage(message); },
       onProjectNameRequest: async () => {
         const ret = await vscode.window.showInputBox({
           prompt: 'Enter a name for the new project',
@@ -813,7 +814,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       }
     };
 
-    const retValue = await quickstartWorkflow(folders, this, callbacks);
+    const retValue = await quickStart.runUiControl(folders, this, callbacks);
 
     return retValue;
   }

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -810,7 +810,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!project_name)
         return -2;
 
-      const target_type = (await vscode.window.showQuickPick(projectTypeDescriptions));
+      const target_type = (await vscode.window.showQuickPick(projectTypeDescriptions, {
+        placeHolder: 'Select a project type',
+      }));
       if (!target_type)
         return -3;
 

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -21,7 +21,7 @@ import {NagManager} from './nag';
 import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
-import * as quickStart from './quickstart';
+import * as quickstart from './quickstart';
 import rollbar from './rollbar';
 import {StateManager} from './state';
 import {StatusBar} from './status';
@@ -789,14 +789,14 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         ? []
         : (vscode.workspace.workspaceFolders!).map(item => item.uri.fsPath);
 
-    const callbacks: quickStart.UiControlCallbacks = {
+    const callbacks: quickstart.UiControlCallbacks = {
       onError: message => { vscode.window.showErrorMessage(message); },
       onWarning: message => { vscode.window.showWarningMessage(message); },
       onProjectNameRequest: async () => {
         const ret = await vscode.window.showInputBox({
           prompt: 'Enter a name for the new project',
-          validateInput: (value: string): string => {
-            if (!value.length)
+          validateInput: (value: string | null): string => {
+            if ((value !== null) && (!value.length))
               return 'A project name is required';
             return '';
           },
@@ -808,13 +808,15 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
           placeHolder: 'Select a project type',
         });
       },
-      onOpenSourceFiles: async file => {
-        const doc = await vscode.workspace.openTextDocument(file);
-        await vscode.window.showTextDocument(doc);
+      onOpenSourceFiles: async( files : quickstart.GeneratedProjectFiles) => {
+        if( files.sourceFiles.length != 0) {
+          const doc = await vscode.workspace.openTextDocument(files.sourceFiles[0]);
+          await vscode.window.showTextDocument(doc);
+        }
       }
     };
 
-    const retValue = await quickStart.runUiControl(folders, this, callbacks);
+    const retValue = await quickstart.runUiControl(folders, this, callbacks);
 
     return retValue;
   }

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -1,0 +1,111 @@
+import * as fsNode from 'fs';
+import * as path from 'path';
+
+import {fs} from './pr';
+
+export enum ProjectType {
+  Library,
+  Exectable
+}
+
+export interface ProjectTypeDesciptor {
+  label: string;
+  type: ProjectType;
+  description: string;
+}
+
+export const projectTypeDescriptions: ProjectTypeDesciptor[] = [
+  {label: 'Library', type: ProjectType.Library, description: 'Create a library'},
+  {label: 'Executable', type: ProjectType.Exectable, description: 'Create an executable'}
+];
+
+export class CMakeQuickStart {
+
+  public readonly cmakeFilePath: string;
+  public project_name: string|undefined;
+  private _type: ProjectType|undefined;
+  private _sourceCodeFilePath: string;
+
+  public get sourceCodeFilePath() { return this._sourceCodeFilePath; }
+
+  public set type(type: ProjectType|undefined) {
+    if (type == ProjectType.Exectable) {
+      this._sourceCodeFilePath = path.join(this.workingPath, 'main.cpp');
+    } else {
+      this._sourceCodeFilePath = path.join(this.workingPath, `${this.project_name}.cpp`);
+    }
+    this._type = type;
+  }
+
+  public get type(): ProjectType|undefined { return this._type; }
+
+  constructor(readonly workingPath: string) {
+
+    this.cmakeFilePath = path.join(this.workingPath, 'CMakeLists.txt');
+
+    if (fsNode.existsSync(this.cmakeFilePath)) {
+      throw Error('Source code directory contains already a CMakeLists.txt');
+    }
+  }
+
+  private async createCMakeListFile() {
+    const init = [
+      'cmake_minimum_required(VERSION 3.0.0)',
+      `project(${this.project_name} VERSION 0.1.0)`,
+      '',
+      'include(CTest)',
+      'enable_testing()',
+      '',
+      this.type == ProjectType.Library ? `add_library(${this.project_name} ${this.project_name}.cpp)`
+                                       : `add_executable(${this.project_name} main.cpp)`,
+      '',
+      'set(CPACK_PROJECT_NAME ${PROJECT_NAME})',
+      'set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})',
+      'include(CPack)',
+      '',
+    ].join('\n');
+
+    return fs.writeFile(this.cmakeFilePath, init);
+  }
+
+  private async createLibrarySourceFile() {
+    return fs.writeFile(this.sourceCodeFilePath, [
+      '#include <iostream>',
+      '',
+      'void say_hello(){',
+      `    std::cout << "Hello, from ${this.project_name}!\\n";`,
+      '}',
+      '',
+    ].join('\n'));
+  }
+
+  private async createMainSourceCodeFile() {
+    return fs.writeFile(this.sourceCodeFilePath, [
+      '#include <iostream>',
+      '',
+      'int main(int, char**) {',
+      '   std::cout << "Hello, world!\\n";',
+      '}',
+      '',
+    ].join('\n'));
+  }
+
+  private async createExampleSourcecodeFile() {
+    if (!(await fs.exists(this.sourceCodeFilePath))) {
+      switch (this.type) {
+      case ProjectType.Library:
+        return this.createLibrarySourceFile();
+      case ProjectType.Exectable:
+        return this.createMainSourceCodeFile();
+      }
+    }
+  }
+
+  public async createProject(project_name: string, type: ProjectType) {
+    this.project_name = project_name;
+    this.type = type;
+
+    await this.createCMakeListFile();
+    await this.createExampleSourcecodeFile();
+  }
+}

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -22,24 +22,17 @@ export const projectTypeDescriptions: ProjectTypeDesciptor[] = [
 export class CMakeQuickStart {
 
   public readonly cmakeFilePath: string;
-  public project_name: string|undefined;
-  private _type: ProjectType|undefined;
-  private _sourceCodeFilePath: string;
+  public readonly sourceCodeFilePath: string;
 
-  public get sourceCodeFilePath() { return this._sourceCodeFilePath; }
+  constructor(readonly workingPath: string,
+      readonly projectName: string,
+      readonly type: ProjectType) {
 
-  public set type(type: ProjectType|undefined) {
     if (type == ProjectType.Exectable) {
-      this._sourceCodeFilePath = path.join(this.workingPath, 'main.cpp');
+      this.sourceCodeFilePath = path.join(this.workingPath, 'main.cpp');
     } else {
-      this._sourceCodeFilePath = path.join(this.workingPath, `${this.project_name}.cpp`);
+      this.sourceCodeFilePath = path.join(this.workingPath, `${projectName}.cpp`);
     }
-    this._type = type;
-  }
-
-  public get type(): ProjectType|undefined { return this._type; }
-
-  constructor(readonly workingPath: string) {
 
     this.cmakeFilePath = path.join(this.workingPath, 'CMakeLists.txt');
 
@@ -51,13 +44,13 @@ export class CMakeQuickStart {
   private async createCMakeListFile() {
     const init = [
       'cmake_minimum_required(VERSION 3.0.0)',
-      `project(${this.project_name} VERSION 0.1.0)`,
+      `project(${this.projectName} VERSION 0.1.0)`,
       '',
       'include(CTest)',
       'enable_testing()',
       '',
-      this.type == ProjectType.Library ? `add_library(${this.project_name} ${this.project_name}.cpp)`
-                                       : `add_executable(${this.project_name} main.cpp)`,
+      this.type == ProjectType.Library ? `add_library(${this.projectName} ${this.projectName}.cpp)`
+                                       : `add_executable(${this.projectName} main.cpp)`,
       '',
       'set(CPACK_PROJECT_NAME ${PROJECT_NAME})',
       'set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})',
@@ -73,7 +66,7 @@ export class CMakeQuickStart {
       '#include <iostream>',
       '',
       'void say_hello(){',
-      `    std::cout << "Hello, from ${this.project_name}!\\n";`,
+      `    std::cout << "Hello, from ${this.projectName}!\\n";`,
       '}',
       '',
     ].join('\n'));
@@ -101,10 +94,7 @@ export class CMakeQuickStart {
     }
   }
 
-  public async createProject(project_name: string, type: ProjectType) {
-    this.project_name = project_name;
-    this.type = type;
-
+  public async createProject() {
     await this.createCMakeListFile();
     await this.createExampleSourcecodeFile();
   }

--- a/src/quickstart.ts
+++ b/src/quickstart.ts
@@ -1,119 +1,122 @@
-import {CMakeToolsAPI} from '@cmt/api';
-import {isCMakeListFilePresent} from '@cmt/util';
-import {fs} from './pr';
-
-import * as fsNode from 'fs';
 import * as path from 'path';
+
+import {CMakeToolsAPI} from './api';
+import * as logging from './logging';
+import {fs} from './pr';
+import {isCMakeListFilePresent} from './util';
+
+const log = logging.createLogger('quickstart');
 
 export enum ProjectType {
   Library,
   Exectable
 }
 
-export interface ProjectTypeDesciptor {
+export interface ProjectTypeDesciption {
   label: string;
   type: ProjectType;
   description: string;
 }
 
-export const projectTypeDescriptions: ProjectTypeDesciptor[] = [
+export const projectTypeDescriptions: ProjectTypeDesciption[] = [
   {label: 'Library', type: ProjectType.Library, description: 'Create a library'},
   {label: 'Executable', type: ProjectType.Exectable, description: 'Create an executable'}
 ];
 
-export class CMakeQuickStart {
+export interface CreateProjectInformation {
+  name: string;
+  type: ProjectType;
+  sourceDirectory: string;
+}
 
-  public readonly cmakeFilePath: string;
-  public readonly sourceCodeFilePath: string;
+export interface GeneratedProjectFiles {
+  cmakeListFile: string;
+  sourceFiles: string[];
+}
 
-  constructor(readonly workingPath: string, readonly projectName: string, readonly type: ProjectType) {
+async function createCMakeListFile(projectInformation: CreateProjectInformation): Promise<string> {
+  const cmakeFilePath = path.join(projectInformation.sourceDirectory, 'CMakeLists.txt');
+  if (await fs.exists(cmakeFilePath)) {
+    throw new Error('Source code directory contains already a CMakeLists.txt');
+  }
 
-    if (type == ProjectType.Exectable) {
-      this.sourceCodeFilePath = path.join(this.workingPath, 'main.cpp');
-    } else {
-      this.sourceCodeFilePath = path.join(this.workingPath, `${projectName}.cpp`);
+  const init = [
+    'cmake_minimum_required(VERSION 3.0.0)',
+    `project(${projectInformation.name} VERSION 0.1.0)`,
+    '',
+    'include(CTest)',
+    'enable_testing()',
+    '',
+    projectInformation.type == ProjectType.Library
+        ? `add_library(${projectInformation.name} ${projectInformation.name}.cpp)`
+        : `add_executable(${projectInformation.name} main.cpp)`,
+    '',
+    'set(CPACK_PROJECT_NAME ${PROJECT_NAME})',
+    'set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})',
+    'include(CPack)',
+    '',
+  ].join('\n');
+
+  await fs.writeFile(cmakeFilePath, init);
+
+  return cmakeFilePath;
+}
+
+async function createLibrarySourceFile(projectInformation: CreateProjectInformation): Promise<string> {
+  const sourceCodeFilePath = path.join(projectInformation.sourceDirectory, `${projectInformation.name}.cpp`);
+  if (await fs.exists(sourceCodeFilePath)) {
+    throw new Error('Library source file is already present.');
+  }
+
+  await fs.writeFile(sourceCodeFilePath, [
+    '#include <iostream>',
+    '',
+    'void say_hello(){',
+    `    std::cout << "Hello, from ${projectInformation.name}!\\n";`,
+    '}',
+    '',
+  ].join('\n'));
+  return sourceCodeFilePath;
+}
+
+async function createMainSourceCodeFile(projectInformation: CreateProjectInformation) {
+  const sourceCodeFilePath = path.join(projectInformation.sourceDirectory, 'main.cpp');
+  if (await fs.exists(sourceCodeFilePath)) {
+    throw new Error('Main source file is already present.');
+  }
+
+  await fs.writeFile(sourceCodeFilePath, [
+    '#include <iostream>',
+    '',
+    'int main(int, char**) {',
+    '   std::cout << "Hello, world!\\n";',
+    '}',
+    '',
+  ].join('\n'));
+
+  return sourceCodeFilePath;
+}
+
+export async function createProject(projectInformation: CreateProjectInformation):
+    Promise<GeneratedProjectFiles> {
+  const cmakeFile = await createCMakeListFile(projectInformation);
+
+  let sourceFile: string = '';
+  try {
+    if (projectInformation.type == ProjectType.Exectable) {
+      sourceFile = await createMainSourceCodeFile(projectInformation);
+    } else if (projectInformation.type == ProjectType.Library) {
+      sourceFile = await createLibrarySourceFile(projectInformation);
     }
+  } catch (err) { log.debug(err); }
 
-    this.cmakeFilePath = path.join(this.workingPath, 'CMakeLists.txt');
-
-  }
-
-  private async createCMakeListFile() : Promise<boolean>{
-    if (fsNode.existsSync(this.cmakeFilePath)) {
-      return false;
-    }
-
-    const init = [
-      'cmake_minimum_required(VERSION 3.0.0)',
-      `project(${this.projectName} VERSION 0.1.0)`,
-      '',
-      'include(CTest)',
-      'enable_testing()',
-      '',
-      this.type == ProjectType.Library ? `add_library(${this.projectName} ${this.projectName}.cpp)`
-      : `add_executable(${this.projectName} main.cpp)`,
-      '',
-      'set(CPACK_PROJECT_NAME ${PROJECT_NAME})',
-      'set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})',
-      'include(CPack)',
-      '',
-    ].join('\n');
-
-    await fs.writeFile(this.cmakeFilePath, init);
-
-    return true;
-  }
-
-  private async createLibrarySourceFile() {
-    return fs.writeFile(this.sourceCodeFilePath, [
-      '#include <iostream>',
-      '',
-      'void say_hello(){',
-      `    std::cout << "Hello, from ${this.projectName}!\\n";`,
-      '}',
-      '',
-    ].join('\n'));
-  }
-
-  private async createMainSourceCodeFile() {
-    return fs.writeFile(this.sourceCodeFilePath, [
-      '#include <iostream>',
-      '',
-      'int main(int, char**) {',
-      '   std::cout << "Hello, world!\\n";',
-      '}',
-      '',
-    ].join('\n'));
-  }
-
-  private async createExampleSourcecodeFile() : Promise<boolean> {
-    if (!(await fs.exists(this.sourceCodeFilePath))) {
-      switch (this.type) {
-      case ProjectType.Library:
-        await this.createLibrarySourceFile();
-        break;
-      case ProjectType.Exectable:
-        await this.createMainSourceCodeFile();
-        break;
-      }
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  public async createProject() : Promise<boolean>{
-    let createdFiles = await this.createCMakeListFile();
-    createdFiles = createdFiles && await this.createExampleSourcecodeFile();
-
-    return createdFiles;
-  }
+  return {cmakeListFile: cmakeFile, sourceFiles: [sourceFile]} as GeneratedProjectFiles;
 }
 
 export interface UiControlCallbacks {
   onProjectNameRequest: () => Promise<string|undefined>;
-  onProjectTypeRequest: (items: ProjectTypeDesciptor[]) => Promise<ProjectTypeDesciptor|undefined>;
-  onOpenSourceFiles: (filePaths: string) => void;
+  onProjectTypeRequest: (items: ProjectTypeDesciption[]) => Promise<ProjectTypeDesciption|undefined>;
+  onOpenSourceFiles: (filePaths: GeneratedProjectFiles) => Promise<void>;
   onError: (message: string) => void;
   onWarning: (message: string) => void;
 }
@@ -126,16 +129,14 @@ export enum ControlErrors {
   PRE_EXISTING_FILES
 }
 
-export async function runUiControl(workspaceFolders: string[],
-                                         cmt: CMakeToolsAPI,
-                                         callbacks: UiControlCallbacks): Promise<ControlErrors> {
+export async function runUiControl(workspaceFolders: string[], cmt: CMakeToolsAPI, callbacks: UiControlCallbacks):
+    Promise<ControlErrors> {
   if (workspaceFolders.length == 0) {
     callbacks.onError('CMake Quick Start: No open folder found.');
     return ControlErrors.NO_FOLDER;
   }
 
   const sourcePath = workspaceFolders[0];
-
   if (await isCMakeListFilePresent(sourcePath)) {
     callbacks.onError('Source code directory contains already a CMakeLists.txt');
     return ControlErrors.PRESENT_CMAKELISTFILE;
@@ -151,12 +152,11 @@ export async function runUiControl(workspaceFolders: string[],
     return ControlErrors.EMPTY_FIELD;
   }
 
-  const helper = new CMakeQuickStart(sourcePath, projectName, projectType.type);
-  if( !await helper.createProject()) {
-    callbacks.onWarning('Not all files are created, because they exist already.');
-  }
+  const project: CreateProjectInformation
+      = {name: projectName, type: projectType.type, sourceDirectory: sourcePath};
 
-  callbacks.onOpenSourceFiles(helper.sourceCodeFilePath);
+  const projectFiles = await createProject(project);
+  await callbacks.onOpenSourceFiles(projectFiles);
 
   await cmt.configure();
   return ControlErrors.NONE;

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import {EnvironmentVariables, execute} from './proc';
+import { fs } from './pr';
 
 /**
  * Escape a string so it can be used as a regular expression
@@ -291,3 +292,7 @@ export function thisExtension() {
 export function thisExtensionPath(): string { return thisExtension().extensionPath; }
 
 export function dropNulls<T>(items: (T|null)[]): T[] { return items.filter(item => item !== null) as T[]; }
+
+export function isCMakeListFilePresent(sourcePath: string): Promise<boolean> {
+  return fs.exists(path.join(sourcePath, "CMakeLists.txt"));
+}

--- a/test/extension-tests/vs-preferred-gen/test/configure-and-build.test.ts
+++ b/test/extension-tests/vs-preferred-gen/test/configure-and-build.test.ts
@@ -15,8 +15,7 @@ suite('Build', async () => {
 
     testEnv = new DefaultEnvironment('test/extension-tests/vs-preferred-gen/project-folder',
                                      'build',
-                                     'output.txt',
-                                     '^Visual ?Studio');
+                                     'output.txt');
     cmt = await CMakeTools.create(testEnv.vsContext);
 
     // This test will use all on the same kit.

--- a/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
+++ b/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
@@ -1,8 +1,8 @@
-import * as path from 'path';
 import {CMakeTools} from '@cmt/cmake-tools';
+import {fs} from '@cmt/pr';
+import {ProjectType} from '@cmt/quickstart';
 import {DefaultEnvironment, expect} from '@test/util';
-import {ProjectType } from '@cmt/quickstart';
-import { fs } from '@cmt/pr';
+import * as path from 'path';
 
 
 suite('[Quickstart]', async () => {
@@ -12,9 +12,8 @@ suite('[Quickstart]', async () => {
   setup(async function(this: Mocha.IBeforeAndAfterContext) {
     this.timeout(100000);
 
-    testEnv = new DefaultEnvironment('test/extension-tests/without-cmakelist-file/project-folder',
-                                     'build',
-                                     'output.txt');
+    testEnv
+        = new DefaultEnvironment('test/extension-tests/without-cmakelist-file/project-folder', 'build', 'output.txt');
     cmt = await CMakeTools.create(testEnv.vsContext);
   });
 
@@ -23,7 +22,6 @@ suite('[Quickstart]', async () => {
     await cmt.asyncDispose();
     testEnv.projectFolder.clear();
     testEnv.teardown();
-
   });
 
   test('Test create new project', async () => {
@@ -44,6 +42,10 @@ suite('[Quickstart]', async () => {
 
     // Check execution of configure()
     expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache is present');
+
+    // Check opening of main file
+    expect(testEnv.openTextDocumentQueue.length).to.be.eq(1);
+    expect(testEnv.openTextDocumentQueue[0]).to.be.contains('main.cpp');
   }).timeout(120000);
 
   test('Test error on CMakeLists.txt file present', async () => {

--- a/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
+++ b/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
@@ -70,6 +70,15 @@ suite('[Quickstart]', async () => {
     expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(false, 'expected cache not present');
   }).timeout(120000);
 
+  test('Test null project name', async () => {
+    testEnv.quickStartProjectNameInput.projectName = null;
+
+    expect(await cmt.quickStart()).to.be.not.eq(0);
+
+    // Check execution of configure()
+    expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(false, 'expected cache not present');
+  }).timeout(120000);
+
   test('Test abort project type', async () => {
     testEnv.quickStartProjectNameInput.projectName = 'Hallo';
     testEnv.quickStartProjectTypeSelection.abort = true;

--- a/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
+++ b/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
@@ -1,0 +1,75 @@
+import * as path from 'path';
+import {CMakeTools} from '@cmt/cmake-tools';
+import {DefaultEnvironment, expect} from '@test/util';
+import {ProjectType } from '@cmt/quickstart';
+import { fs } from '@cmt/pr';
+
+
+suite('[Quickstart]', async () => {
+  let cmt: CMakeTools;
+  let testEnv: DefaultEnvironment;
+
+  setup(async function(this: Mocha.IBeforeAndAfterContext) {
+    this.timeout(100000);
+
+    testEnv = new DefaultEnvironment('test/extension-tests/without-cmakelist-file/project-folder',
+                                     'build',
+                                     'output.txt');
+    cmt = await CMakeTools.create(testEnv.vsContext);
+  });
+
+  teardown(async function(this: Mocha.IBeforeAndAfterContext) {
+    this.timeout(30000);
+    await cmt.asyncDispose();
+    testEnv.projectFolder.clear();
+    testEnv.teardown();
+
+  });
+
+  test('Test create new project', async () => {
+    testEnv.quickStartProjectTypeSelection.type = ProjectType.Exectable;
+    testEnv.quickStartProjectNameInput.projectName = 'Hallo';
+    expect(await cmt.quickStart()).to.be.eq(0);
+
+    // Check that no error war created at quickstart workflow
+    expect(testEnv.errorMessagesQueue.length).to.be.eq(0);
+
+    // Check creation of cmake file
+    expect(testEnv.projectFolder.cmakeListContent).to.contain('project(Hallo VERSION 0.1.0)');
+
+    // Check execution of configure()
+    expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache is present');
+  }).timeout(120000);
+
+  test('Test error on CMakeLists.txt file present', async () => {
+    await fs.writeFile(path.join(testEnv.projectFolder.location, 'CMakeLists.txt'), 'dummy');
+
+    expect(await cmt.quickStart()).to.be.not.eq(0);
+
+    // Check that no error war created at quickstart workflow
+    expect(testEnv.errorMessagesQueue.length).to.be.eq(1);
+    expect(testEnv.errorMessagesQueue[0]).to.contain('Source code directory contains already a CMakeLists.txt');
+
+    // Check execution of configure()
+    expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(false, 'expected cache not present');
+  }).timeout(120000);
+
+  test('Test no project name', async () => {
+    testEnv.quickStartProjectNameInput.projectName = '';
+
+    expect(await cmt.quickStart()).to.be.not.eq(0);
+
+    // Check execution of configure()
+    expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(false, 'expected cache not present');
+  }).timeout(120000);
+
+  test('Test abort project type', async () => {
+    testEnv.quickStartProjectNameInput.projectName = 'Hallo';
+    testEnv.quickStartProjectTypeSelection.abort = true;
+
+    expect(await cmt.quickStart()).to.be.not.eq(0);
+
+    // Check execution of configure()
+    expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(false, 'expected cache not present');
+  }).timeout(120000);
+});

--- a/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
+++ b/test/extension-tests/without-cmakelist-file/test/quickstart.test.ts
@@ -27,6 +27,11 @@ suite('[Quickstart]', async () => {
   });
 
   test('Test create new project', async () => {
+    // select default kit
+    await cmt.scanForKits();
+    await cmt.selectKit();
+
+    // run quick start
     testEnv.quickStartProjectTypeSelection.type = ProjectType.Exectable;
     testEnv.quickStartProjectNameInput.projectName = 'Hallo';
     expect(await cmt.quickStart()).to.be.eq(0);

--- a/test/helpers/cmake/project-root-helper.ts
+++ b/test/helpers/cmake/project-root-helper.ts
@@ -1,4 +1,7 @@
+
+import * as fs from 'fs';
 import * as path from 'path';
+import * as rimraf from 'rimraf';
 import {BuildDirectoryHelper} from './build-directory-helper';
 
 
@@ -19,4 +22,17 @@ export class ProjectRootHelper {
   public get buildDirectory(): BuildDirectoryHelper { return this._buildFolder; }
 
   public get location(): string { return this._projectRoot; }
+
+  public clear() {
+    return rimraf.sync(path.join(this.location, '*'));
+  }
+
+  public get cmakeListContent(): string {
+    const cmakeFilePath = path.join(this.location, 'CMakeLists.txt');
+    if (fs.existsSync(cmakeFilePath)) {
+      return fs.readFileSync(cmakeFilePath).toString();
+    } else {
+      return '';
+    }
+  }
 }

--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -78,7 +78,7 @@ export class DefaultEnvironment {
 
   private setupShowInputBoxStub(selections: InputBoxPromt[]) {
     this.sandbox.stub(vscode.window, 'showInputBox')
-        .callsFake((options: vscode.InputBoxOptions): Thenable<string|undefined> => {
+        .callsFake((options: vscode.InputBoxOptions): Thenable<string|null> => {
           for (const selector of selections) {
             if (options.prompt == selector.identifier) {
               return Promise.resolve(selector.provideResponse());

--- a/test/helpers/vscodefake/input-box.ts
+++ b/test/helpers/vscodefake/input-box.ts
@@ -1,18 +1,16 @@
 
 
 export interface InputBoxPromt {
-    identifier: string;
+  identifier: string;
 
-    provideResponse(): string;
+  provideResponse(): string|null;
 }
 
 
 export class QuickStartProjectNameInputBox implements InputBoxPromt {
-    identifier: string = 'Enter a name for the new project';
+  identifier: string = 'Enter a name for the new project';
 
-    public projectName : string = "";
+  public projectName: string|null;
 
-    provideResponse(): string {
-        return this.projectName;
-    }
+  provideResponse(): string|null { return this.projectName; }
 }

--- a/test/helpers/vscodefake/input-box.ts
+++ b/test/helpers/vscodefake/input-box.ts
@@ -1,0 +1,18 @@
+
+
+export interface InputBoxPromt {
+    identifier: string;
+
+    provideResponse(): string;
+}
+
+
+export class QuickStartProjectNameInputBox implements InputBoxPromt {
+    identifier: string = 'Enter a name for the new project';
+
+    public projectName : string = "";
+
+    provideResponse(): string {
+        return this.projectName;
+    }
+}

--- a/test/helpers/vscodefake/quick-picker.ts
+++ b/test/helpers/vscodefake/quick-picker.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import { ProjectTypeDesciptor, ProjectType } from '@cmt/quickstart';
+import { ProjectTypeDesciption, ProjectType } from '@cmt/quickstart';
 
 export interface QuickPickerHandleStrategy {
   identifier: string;
@@ -13,7 +13,7 @@ export class SelectProjectTypePickerHandle implements QuickPickerHandleStrategy 
 
   public get identifier(): string { return 'Select a project type'; }
 
-  public handleQuickPick(items: ProjectTypeDesciptor[]): any {
+  public handleQuickPick(items: ProjectTypeDesciption[]): any {
     if (this.abort) {
       return null;
     }

--- a/test/helpers/vscodefake/quick-picker.ts
+++ b/test/helpers/vscodefake/quick-picker.ts
@@ -1,9 +1,24 @@
 import {expect} from 'chai';
+import { ProjectTypeDesciptor, ProjectType } from '@cmt/quickstart';
 
 export interface QuickPickerHandleStrategy {
   identifier: string;
 
   handleQuickPick(items: any): any;
+}
+
+export class SelectProjectTypePickerHandle implements QuickPickerHandleStrategy {
+  public type: ProjectType.Exectable;
+  public abort: boolean = false;
+
+  public get identifier(): string { return 'Select a project type'; }
+
+  public handleQuickPick(items: ProjectTypeDesciptor[]): any {
+    if (this.abort) {
+      return null;
+    }
+    return items.find( item => item.type == this.type)!;
+  }
 }
 
 export class SelectKitPickerHandle implements QuickPickerHandleStrategy {

--- a/test/unit-tests/quickstart.test.ts
+++ b/test/unit-tests/quickstart.test.ts
@@ -1,0 +1,88 @@
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as path from 'path';
+
+chai.use(chaiAsPromised);
+
+import {expect} from 'chai';
+import {CMakeQuickStart, ProjectType} from '../../src/quickstart';
+import {fs} from '../../src/pr';
+
+// tslint:disable:no-unused-expression
+
+const here = __dirname;
+function getTestWorkspace(): string { return path.normalize(path.join(here, '../../../', 'testWorkspace')); }
+
+
+suite('QuickStart test', async () => {
+  const working_path = getTestWorkspace();
+  setup(async () => { await fs.mkdir_p(working_path); });
+
+  teardown(async () => { await fs.rmdir(working_path); });
+
+  test('CMakeLists.txt exists', async () => {
+    await fs.writeFile(path.join(working_path, 'CMakeLists.txt'), 'Dummy');
+
+    expect(() => new CMakeQuickStart(working_path)).to.throws(
+        'Source code directory contains already a CMakeLists.txt');
+  });
+
+
+  test('Create library', async () => {
+    const obj = new CMakeQuickStart(working_path);
+    await obj.createProject('libraryTest', ProjectType.Library);
+
+    // Check cmake file
+    const cmakeFilePath = path.join(working_path, 'CMakeLists.txt');
+    expect(await fs.exists(cmakeFilePath), 'Expect new CMakeLists.txt file in workspace_path').to.be.true;
+
+    const cmakeListContent = (await fs.readFile(cmakeFilePath)).toString();
+    expect(cmakeListContent).to.contain('add_library(libraryTest libraryTest.cpp)');
+    expect(cmakeListContent).to.contain('project(libraryTest VERSION 0.1.0)');
+
+    // Check library source code
+    const libraryBodyFilePath = path.join(working_path, 'libraryTest.cpp');
+    expect(await fs.exists(libraryBodyFilePath), 'Expect new "libraryTest.cpp" in workspace_path').to.be.true;
+    const libraryBodyFileContent = (await fs.readFile(libraryBodyFilePath)).toString();
+    expect(libraryBodyFileContent).to.contain('std::cout << "Hello, from libraryTest!\\n"');
+  });
+
+  test('Create library file exists', async () => {
+    const libraryBodyFilePath = path.join(working_path, 'libraryTest.cpp');
+    await fs.writeFile(libraryBodyFilePath, 'OldFile');
+    const obj = new CMakeQuickStart(working_path);
+    await obj.createProject('libraryTest', ProjectType.Exectable);
+
+    const libraryBodyFileContent = (await fs.readFile(libraryBodyFilePath)).toString();
+    expect(libraryBodyFileContent, 'libraryTest.cpp file is overwritten unexpected.').to.contain('OldFile');
+  });
+
+  test('Create executeable', async () => {
+    const obj = new CMakeQuickStart(working_path);
+    await obj.createProject('executableTest', ProjectType.Exectable);
+
+    // Check cmake file
+    const cmakeFilePath = path.join(working_path, 'CMakeLists.txt');
+    expect(await fs.exists(cmakeFilePath), 'Expect new CMakeLists.txt file in workspace_path').to.be.true;
+
+    const cmakeListContent = (await fs.readFile(cmakeFilePath)).toString();
+    expect(cmakeListContent).to.contain('add_executable(executableTest main.cpp)');
+    expect(cmakeListContent).to.contain('project(executableTest VERSION 0.1.0)');
+
+    // Check source code
+    const executableBodyFilePath = path.join(working_path, 'main.cpp');
+    expect(await fs.exists(executableBodyFilePath), 'Expect new "main.cpp" in workspace_path').to.be.true;
+    const executableBodyFileContent = (await fs.readFile(executableBodyFilePath)).toString();
+    expect(executableBodyFileContent).to.contain('std::cout << "Hello, world!\\n";');
+  });
+
+  test('Create executable file exists', async () => {
+    const mainFilePath = path.join(working_path, 'main.cpp');
+    await fs.writeFile(mainFilePath, 'OldFile');
+    const obj = new CMakeQuickStart(working_path);
+    await obj.createProject('executableTest', ProjectType.Exectable);
+
+    const mainBodyFileContent = (await fs.readFile(mainFilePath)).toString();
+    expect(mainBodyFileContent, 'Main body file is overwritten unexpected.').to.contain('OldFile');
+  });
+});

--- a/test/unit-tests/quickstart.test.ts
+++ b/test/unit-tests/quickstart.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 chai.use(chaiAsPromised);
 
 import {expect} from 'chai';
-import {CMakeQuickStart, ProjectType} from '../../src/quickstart';
+import * as quickstart from '../../src/quickstart';
 import {fs} from '../../src/pr';
 
 // tslint:disable:no-unused-expression
@@ -14,7 +14,7 @@ const here = __dirname;
 function getTestWorkspace(): string { return path.normalize(path.join(here, '../../../', 'testWorkspace')); }
 
 
-suite('QuickStart test', async () => {
+suite.only('QuickStart test', async () => {
   const working_path = getTestWorkspace();
   setup(async () => { await fs.mkdir_p(working_path); });
 
@@ -23,25 +23,32 @@ suite('QuickStart test', async () => {
   test('CMakeLists.txt exists', async () => {
     await fs.writeFile(path.join(working_path, 'CMakeLists.txt'), 'Dummy');
 
-    expect(() => new CMakeQuickStart(working_path, "", ProjectType.Exectable)).to.throws(
-        'Source code directory contains already a CMakeLists.txt');
+    const project: quickstart.CreateProjectInformation
+        = {name: '', type: quickstart.ProjectType.Exectable, sourceDirectory: working_path};
+    quickstart.createProject(project)
+        .then(() => { throw new Error('was not supposed to succeed'); })
+        .catch(m => expect(m).to.equal('Source code directory contains already a CMakeLists.txt'));
   });
 
 
   test('Create library', async () => {
-    const obj = new CMakeQuickStart(working_path, 'libraryTest', ProjectType.Library);
-    await obj.createProject();
+    const project: quickstart.CreateProjectInformation
+        = {name: 'libraryTest', type: quickstart.ProjectType.Library, sourceDirectory: working_path};
+    const projectFiles = await quickstart.createProject(project);
 
     // Check cmake file
     const cmakeFilePath = path.join(working_path, 'CMakeLists.txt');
-    expect(await fs.exists(cmakeFilePath), 'Expect new CMakeLists.txt file in workspace_path').to.be.true;
+    expect(projectFiles.cmakeListFile).to.be.eq(cmakeFilePath);
 
+    expect(await fs.exists(cmakeFilePath), 'Expect new CMakeLists.txt file in workspace_path').to.be.true;
     const cmakeListContent = (await fs.readFile(cmakeFilePath)).toString();
     expect(cmakeListContent).to.contain('add_library(libraryTest libraryTest.cpp)');
     expect(cmakeListContent).to.contain('project(libraryTest VERSION 0.1.0)');
 
     // Check library source code
     const libraryBodyFilePath = path.join(working_path, 'libraryTest.cpp');
+    expect(projectFiles.sourceFiles[0]).to.be.eq(libraryBodyFilePath);
+
     expect(await fs.exists(libraryBodyFilePath), 'Expect new "libraryTest.cpp" in workspace_path').to.be.true;
     const libraryBodyFileContent = (await fs.readFile(libraryBodyFilePath)).toString();
     expect(libraryBodyFileContent).to.contain('std::cout << "Hello, from libraryTest!\\n"');
@@ -50,27 +57,33 @@ suite('QuickStart test', async () => {
   test('Create library file exists', async () => {
     const libraryBodyFilePath = path.join(working_path, 'libraryTest.cpp');
     await fs.writeFile(libraryBodyFilePath, 'OldFile');
-    const obj = new CMakeQuickStart(working_path, 'libraryTest', ProjectType.Exectable);
-    await obj.createProject();
+
+    const project: quickstart.CreateProjectInformation
+        = {name: 'libraryTest', type: quickstart.ProjectType.Library, sourceDirectory: working_path};
+    await quickstart.createProject(project);
 
     const libraryBodyFileContent = (await fs.readFile(libraryBodyFilePath)).toString();
     expect(libraryBodyFileContent, 'libraryTest.cpp file is overwritten unexpected.').to.contain('OldFile');
   });
 
   test('Create executeable', async () => {
-    const obj = new CMakeQuickStart(working_path, 'executableTest', ProjectType.Exectable);
-    await obj.createProject();
+    const project: quickstart.CreateProjectInformation
+        = {name: 'executableTest', type: quickstart.ProjectType.Exectable, sourceDirectory: working_path};
+    const projectFiles = await quickstart.createProject(project);
 
     // Check cmake file
     const cmakeFilePath = path.join(working_path, 'CMakeLists.txt');
-    expect(await fs.exists(cmakeFilePath), 'Expect new CMakeLists.txt file in workspace_path').to.be.true;
+    expect(projectFiles.cmakeListFile).to.be.eq(cmakeFilePath);
 
+    expect(await fs.exists(cmakeFilePath), 'Expect new CMakeLists.txt file in workspace_path').to.be.true;
     const cmakeListContent = (await fs.readFile(cmakeFilePath)).toString();
     expect(cmakeListContent).to.contain('add_executable(executableTest main.cpp)');
     expect(cmakeListContent).to.contain('project(executableTest VERSION 0.1.0)');
 
     // Check source code
     const executableBodyFilePath = path.join(working_path, 'main.cpp');
+    expect(projectFiles.sourceFiles[0]).to.be.eq(executableBodyFilePath);
+
     expect(await fs.exists(executableBodyFilePath), 'Expect new "main.cpp" in workspace_path').to.be.true;
     const executableBodyFileContent = (await fs.readFile(executableBodyFilePath)).toString();
     expect(executableBodyFileContent).to.contain('std::cout << "Hello, world!\\n";');
@@ -79,8 +92,10 @@ suite('QuickStart test', async () => {
   test('Create executable file exists', async () => {
     const mainFilePath = path.join(working_path, 'main.cpp');
     await fs.writeFile(mainFilePath, 'OldFile');
-    const obj = new CMakeQuickStart(working_path,'executableTest', ProjectType.Exectable);
-    await obj.createProject();
+
+    const project: quickstart.CreateProjectInformation
+        = {name: 'executableTest', type: quickstart.ProjectType.Exectable, sourceDirectory: working_path};
+    await quickstart.createProject(project);
 
     const mainBodyFileContent = (await fs.readFile(mainFilePath)).toString();
     expect(mainBodyFileContent, 'Main body file is overwritten unexpected.').to.contain('OldFile');

--- a/test/unit-tests/quickstart.test.ts
+++ b/test/unit-tests/quickstart.test.ts
@@ -23,14 +23,14 @@ suite('QuickStart test', async () => {
   test('CMakeLists.txt exists', async () => {
     await fs.writeFile(path.join(working_path, 'CMakeLists.txt'), 'Dummy');
 
-    expect(() => new CMakeQuickStart(working_path)).to.throws(
+    expect(() => new CMakeQuickStart(working_path, "", ProjectType.Exectable)).to.throws(
         'Source code directory contains already a CMakeLists.txt');
   });
 
 
   test('Create library', async () => {
-    const obj = new CMakeQuickStart(working_path);
-    await obj.createProject('libraryTest', ProjectType.Library);
+    const obj = new CMakeQuickStart(working_path, 'libraryTest', ProjectType.Library);
+    await obj.createProject();
 
     // Check cmake file
     const cmakeFilePath = path.join(working_path, 'CMakeLists.txt');
@@ -50,16 +50,16 @@ suite('QuickStart test', async () => {
   test('Create library file exists', async () => {
     const libraryBodyFilePath = path.join(working_path, 'libraryTest.cpp');
     await fs.writeFile(libraryBodyFilePath, 'OldFile');
-    const obj = new CMakeQuickStart(working_path);
-    await obj.createProject('libraryTest', ProjectType.Exectable);
+    const obj = new CMakeQuickStart(working_path, 'libraryTest', ProjectType.Exectable);
+    await obj.createProject();
 
     const libraryBodyFileContent = (await fs.readFile(libraryBodyFilePath)).toString();
     expect(libraryBodyFileContent, 'libraryTest.cpp file is overwritten unexpected.').to.contain('OldFile');
   });
 
   test('Create executeable', async () => {
-    const obj = new CMakeQuickStart(working_path);
-    await obj.createProject('executableTest', ProjectType.Exectable);
+    const obj = new CMakeQuickStart(working_path, 'executableTest', ProjectType.Exectable);
+    await obj.createProject();
 
     // Check cmake file
     const cmakeFilePath = path.join(working_path, 'CMakeLists.txt');
@@ -79,8 +79,8 @@ suite('QuickStart test', async () => {
   test('Create executable file exists', async () => {
     const mainFilePath = path.join(working_path, 'main.cpp');
     await fs.writeFile(mainFilePath, 'OldFile');
-    const obj = new CMakeQuickStart(working_path);
-    await obj.createProject('executableTest', ProjectType.Exectable);
+    const obj = new CMakeQuickStart(working_path,'executableTest', ProjectType.Exectable);
+    await obj.createProject();
 
     const mainBodyFileContent = (await fs.readFile(mainFilePath)).toString();
     expect(mainBodyFileContent, 'Main body file is overwritten unexpected.').to.contain('OldFile');


### PR DESCRIPTION
## This change addresses item #340 and #366 and tests for #363

### This changes refactors cmake command quickstart 

The following changes are proposed:

- Separate UI from business logic
- Add tests for business logic of quick start
- Add tests for quick start UI

- [ ] Clearify use of `cmake.sourceDirectory`  in quick start (Chicken or the egg Problem, because there is no CMakeFile which could be used by the driver. The driver is needed for substitution yet.)
- [ ] Tests for UI without folder
- [x] Tests for open source code
- [ ] Tests for check correctness for project templates 
