### PR TITLE
Feature/workspace folder

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -190,15 +190,28 @@ export abstract class CMakeDriver implements vscode.Disposable {
   }
 
   /**
+   * Get the vscode root workspace folder.
+   *
+   * @returns Returns the vscode root workspace folder. Returns `null` if no folder is open or the folder uri is not a `file://` scheme.
+   */
+  private get _workspaceRootPath() {
+    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders[0].uri.scheme !== 'file') {
+      return null
+    }
+    return util.normalizePath(vscode.workspace.workspaceFolders[0].uri.fsPath);
+  }
+
+  /**
    * The options that will be passed to `expand.expandString` for this driver.
    */
   get expansionOptions(): expand.ExpansionOptions {
-    const ws_root = util.normalizePath(vscode.workspace.rootPath || '.');
+    const ws_root = this._workspaceRootPath || '.';
     const user_dir = process.platform === 'win32' ? process.env['HOMEPATH']! : process.env['HOME']!;
 
     // Fill in default replacements
     const vars: expand.ExpansionVars = {
       workspaceRoot: ws_root,
+      workspaceFolder: ws_root,
       buildType: this.currentBuildType,
       workspaceRootFolderName: path.basename(ws_root),
       generator: this.generatorName || 'null',

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -196,7 +196,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    */
   private get _workspaceRootPath() {
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders[0].uri.scheme !== 'file') {
-      return null
+      return null;
     }
     return util.normalizePath(vscode.workspace.workspaceFolders[0].uri.fsPath);
   }

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -20,6 +20,7 @@ const log = createLogger('expand');
  */
 export interface RequiredExpansionContextVars {
   workspaceRoot: string;
+  workspaceFolder: string;
   buildType: string;
   workspaceRootFolderName: string;
   generator: string;

--- a/test/extension-tests/successful-build/test/variable-substitution.test.ts
+++ b/test/extension-tests/successful-build/test/variable-substitution.test.ts
@@ -49,6 +49,23 @@ suite('[Variable Substitution]', async () => {
     expect(typeof cacheEntry.value).to.eq('string', '[workspaceRoot] unexpected cache entry value type');
   }).timeout(60000);
 
+  test('Check substitution for "workspaceFolder"', async () => {
+    // Set fake settings
+    testEnv.setting.changeSetting('configureSettings', {workspaceFolder: '${workspaceFolder}'});
+
+    // Configure
+    expect(await cmt.configure()).to.be.eq(0, '[workspaceFolder] configure failed');
+    expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache not present');
+    const cache = await CMakeCache.fromPath(await cmt.cachePath);
+
+    const cacheEntry = cache.get('workspaceFolder') as api.CacheEntry;
+    expect(cacheEntry.type).to.eq(api.CacheEntryType.String, '[workspaceFolder] unexpected cache entry type');
+    expect(cacheEntry.key).to.eq('workspaceFolder', '[workspaceFolder] unexpected cache entry key name');
+    expect(normalizePath(cacheEntry.as<string>()))
+        .to.eq(normalizePath(testEnv.projectFolder.location), '[workspaceFolder] substitution incorrect');
+    expect(typeof cacheEntry.value).to.eq('string', '[workspaceFolder] unexpected cache entry value type');
+  }).timeout(60000);
+
   test('Check substitution for "buildType"', async () => {
     // Set fake settings
     testEnv.setting.changeSetting('configureSettings', {buildType: '${buildType}'});


### PR DESCRIPTION

## This change addresses item #367 

### This changes variable substitution and corresponding tests

The following changes are proposed:

- Add variable workspaceFolder to expansion Options
- Added test for the change

## Other Notes/Information

Also replaced deprecated `workspace.rootPath` with `workspace.workspaceFolders[0]`
