### PR TITLE
[windows] Use quotes to allow spaces in path

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -303,13 +303,13 @@ export interface VSInstallation {
 export async function vsInstallations(): Promise<VSInstallation[]> {
   const installs = [] as VSInstallation[];
   const inst_ids = [] as string[];
-  const vswhere_exe = path.join(thisExtensionPath(), 'res/vswhere.exe');
+  const vswhere_exe = path.join(thisExtensionPath(), 'res', 'vswhere.exe');
   const sys32_path = path.join(process.env.WINDIR as string, 'System32');
 
   const vswhere_args =
-      ['/c', `${sys32_path}\\chcp 65001 | ${vswhere_exe} -all -format json -products * -legacy -prerelease`];
+      ['/c', `${sys32_path}\\chcp 65001 | "${vswhere_exe}" -all -format json -products * -legacy -prerelease`];
   const vswhere_res
-      = await proc.execute(`${sys32_path}\\cmd.exe`, vswhere_args, null, {silent: true, encoding: 'utf8'}).result;
+      = await proc.execute(`${sys32_path}\\cmd.exe`, vswhere_args, null, {silent: true, encoding: 'utf8', shell: true}).result;
 
   if (vswhere_res.retc !== 0) {
     log.error('Failed to execute vswhere.exe:', vswhere_res.stderr);


### PR DESCRIPTION
The following changes are proposed:

- Quotes around `vswhere_exe` path.

## The purpose of this change

For the case where `vswhere_exe` path has a whitespace character.

## Other Notes/Information

On Windows, my username has a whitespace ("Tushar Maheshwari" in my case).
VS Code stores the installed extensions, and their resources in the home directory, which has the username in the path.
The extension uses `vswhere` without quotes, which fails with:
```
'C:\Users\Tushar' is not recognized as an internal or external command, operable program or batch file.
```
Tried locally with the changes, the extension succeeds in executing `vswhere` and continues execution.