### PR TITLE
Implement better configure-dirty checks.

### DIFF
--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -464,6 +464,7 @@ export class CMakeServerClient {
   sendRequest(t: 'configure', p: ConfigureParams): Promise<ConfigureContent>;
   sendRequest(t: 'compute', p?: ComputeParams): Promise<ComputeContent>;
   sendRequest(t: 'codemodel', p?: CodeModelParams): Promise<CodeModelContent>;
+  sendRequest(t: 'cmakeInputs', p?: CMakeInputsParams): Promise<CMakeInputsContent>;
   sendRequest(T: 'cache', p?: CacheParams): Promise<CacheContent>;
   sendRequest(type: string, params: any = {}): Promise<any> {
     const cp = {type, ...params};
@@ -492,6 +493,8 @@ export class CMakeServerClient {
   compute(params?: ComputeParams): Promise<ComputeParams> { return this.sendRequest('compute', params); }
 
   codemodel(params?: CodeModelParams): Promise<CodeModelContent> { return this.sendRequest('codemodel', params); }
+
+  cmakeInputs(params?: CMakeInputsParams): Promise<CMakeInputsContent> { return this.sendRequest('cmakeInputs', params); }
 
   private _onErrorData(data: Uint8Array) {
     log.error(`Unexpected stderr/stdout data from CMake Server process: ${data.toString()}`);

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import {InputFile, InputFileSet} from '@cmt/dirty';
+import {InputFileSet} from '@cmt/dirty';
 import * as api from './api';
 import {CacheEntryProperties, ExecutableTarget, RichTarget} from './api';
 import * as cache from './cache';

--- a/src/dirty.ts
+++ b/src/dirty.ts
@@ -1,0 +1,64 @@
+/**
+ * A module for doing very primitive dirty-checking
+ */ /** */
+
+import {CMakeInputsContent} from '@cmt/cms-client';
+import {fs} from '@cmt/pr';
+import * as util from '@cmt/util';
+import {Stats} from 'fs';
+import * as path from 'path';
+
+export class InputFile {
+  constructor(readonly filePath: string, readonly mtime: Date|null) {}
+
+  async checkOutOfDate(): Promise<boolean> {
+    if (this.mtime === null) {
+      return true;
+    }
+    let stat: Stats;
+    try {
+      stat = await fs.stat(this.filePath);
+    } catch (_) {
+      // Failed to stat: Treat the file as out-of-date
+      return true;
+    }
+    return stat.mtime.valueOf() > this.mtime.valueOf();
+  }
+
+  static async create(filePath: string): Promise<InputFile> {
+    let stat: Stats;
+    try {
+      stat = await fs.stat(filePath);
+    } catch (_) { return new InputFile(filePath, null); }
+    return new InputFile(filePath, stat.mtime);
+  }
+}
+
+export class InputFileSet {
+  private constructor(readonly inputFiles: InputFile[]) { }
+
+  async checkOutOfDate(): Promise<boolean> {
+    for (const input of this.inputFiles) {
+      if (await input.checkOutOfDate()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static async create(cmake_inputs: CMakeInputsContent): Promise<InputFileSet> {
+    const input_files
+        = await Promise.all(util.map(util.flatMap(cmake_inputs.buildFiles, entry => entry.sources), src => {
+            // Map input file paths to files relative to the source directory
+            if (!path.isAbsolute(src)) {
+              src = util.normalizePath(path.join(cmake_inputs.sourceDirectory, src));
+            }
+            return InputFile.create(src);
+          }));
+    return new InputFileSet(input_files);
+  }
+
+  static createEmpty(): InputFileSet {
+    return new InputFileSet([]);
+  }
+}

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -51,7 +51,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
   /**
    * Check if we need to reconfigure, such as if an important file has changed
    */
-  abstract get needsReconfigure(): boolean;
+  abstract checkNeedsReconfigure(): Promise<boolean>;
 
   /**
    * List of targets known to CMake
@@ -521,7 +521,7 @@ Please install or configure a preferred generator, or update settings.json or yo
   get onReconfigured(): vscode.Event<void> { return this._onReconfiguredEmitter.event; }
 
   async configure(extra_args: string[], consumer?: proc.OutputConsumer): Promise<number> {
-    const pre_check_ok = await this._beforeConfigure();
+    const pre_check_ok = await this._beforeConfigureOrBuild();
     if (!pre_check_ok) {
       return -1;
     }
@@ -618,11 +618,11 @@ Please install or configure a preferred generator, or update settings.json or yo
   }
 
   /**
-   * Execute pre-configure tasks to check if we are ready to run a full
+   * Execute pre-configure/build tasks to check if we are ready to run a full
    * configure. This should be called by a derived driver before any
    * configuration tasks are run
    */
-  private async _beforeConfigure(): Promise<boolean> {
+  private async _beforeConfigureOrBuild(): Promise<boolean> {
     log.debug('Runnnig pre-configure checks and steps');
     if (this._isBusy) {
       if (config.autoRestartBuild) {
@@ -652,26 +652,6 @@ Please install or configure a preferred generator, or update settings.json or yo
       return false;
     }
 
-    // Save open files before we configure/build
-    if (config.saveBeforeBuild) {
-      log.debug('Saving open files before configure/build');
-      const save_good = await vscode.workspace.saveAll();
-      if (!save_good) {
-        log.debug('Saving open files failed');
-        const chosen = await vscode.window.showErrorMessage<
-            vscode.MessageItem>('Not all open documents were saved. Would you like to continue anyway?',
-                                {
-                                  title: 'Yes',
-                                  isCloseAffordance: false,
-                                },
-                                {
-                                  title: 'No',
-                                  isCloseAffordance: true,
-                                });
-        return chosen !== undefined && (chosen.title === 'Yes');
-      }
-    }
-
     return true;
   }
 
@@ -682,7 +662,7 @@ Please install or configure a preferred generator, or update settings.json or yo
   private _currentProcess: proc.Subprocess|null = null;
 
   private async _doCMakeBuild(target: string, consumer?: proc.OutputConsumer): Promise<proc.Subprocess|null> {
-    const ok = await this._beforeConfigure();
+    const ok = await this._beforeConfigureOrBuild();
     if (!ok) {
       return null;
     }

--- a/src/legacy-driver.ts
+++ b/src/legacy-driver.ts
@@ -29,7 +29,7 @@ export class LegacyCMakeDriver extends CMakeDriver {
   private constructor(state: StateManager) { super(state); }
 
   private _needsReconfigure = true;
-  get needsReconfigure() { return this._needsReconfigure; }
+  async checkNeedsReconfigure(): Promise<boolean> { return this._needsReconfigure; }
 
   async doSetKit(need_clean: boolean, cb: () => Promise<void>): Promise<void> {
     this._needsReconfigure = true;

--- a/src/util.ts
+++ b/src/util.ts
@@ -240,6 +240,15 @@ export function versionGreater(lhs: Version, rhs: Version|string): boolean {
   return false;
 }
 
+export function* flatMap<In, Out>(rng: Iterable<In>, fn: (item: In) => Iterable<Out>): Iterable<Out> {
+  for (const elem of rng) {
+    const mapped = fn(elem);
+    for (const other_elem of mapped) {
+      yield other_elem;
+    }
+  }
+}
+
 export function versionEquals(lhs: Version, rhs: Version|string): boolean {
   if (typeof (rhs) === 'string') {
     return versionEquals(lhs, parseVersion(rhs));

--- a/test/unit-tests/dirty.test.ts
+++ b/test/unit-tests/dirty.test.ts
@@ -1,4 +1,5 @@
 import { InputFile, InputFileSet } from '@cmt/dirty';
+import * as util from '@cmt/util';
 import {expect} from '@test/util';
 import * as path from 'path';
 import { fs } from '@cmt/pr';
@@ -65,7 +66,7 @@ suite('Dirty file checking', async () => {
 
   test('Input file set maps files correctly', async () => {
     const foo_subdir = path.join(here, 'foo');
-    const dummy_file = path.join(foo_subdir, 'dummy_file');
+    const dummy_file = util.normalizePath(path.join(foo_subdir, 'dummy_file'));
     const fileset = await InputFileSet.create({
       buildFiles: [{
         isCMake: false,

--- a/test/unit-tests/dirty.test.ts
+++ b/test/unit-tests/dirty.test.ts
@@ -1,0 +1,89 @@
+import { InputFile, InputFileSet } from '@cmt/dirty';
+import {expect} from '@test/util';
+import * as path from 'path';
+import { fs } from '@cmt/pr';
+
+// tslint:disable:no-unused-expression
+
+
+const here = __dirname;
+function getTestResourceFilePath(filename: string): string {
+  return path.normalize(path.join(here, '../../../test/unit-tests', filename));
+}
+
+suite('Dirty file checking', async () => {
+  const test_file_path = getTestResourceFilePath('dirty-test-file');
+  setup(async () => {
+    if (await fs.exists(test_file_path)) {
+      await fs.unlink(test_file_path);
+    }
+  });
+
+  teardown(async () => {
+    if (await fs.exists(test_file_path)) {
+      await fs.unlink(test_file_path);
+    }
+  });
+
+  test('Check dirty on a non-existent file', async () => {
+    const input = await InputFile.create(test_file_path);
+    // Non-existing files are considered modified
+    expect(await input.checkOutOfDate());
+  });
+
+  test('Create a file after stating', async () => {
+    const input = await InputFile.create(test_file_path);
+    // File does not yet exist, check that it is considered modified
+    expect(await input.checkOutOfDate());
+    await fs.writeFile(test_file_path, 'dummy');
+    // Still considered modified
+    expect(await input.checkOutOfDate());
+  });
+
+  test('Delete a file after stating', async () => {
+    await fs.writeFile(test_file_path, 'dummy');
+    const input = await InputFile.create(test_file_path);
+    // We haven't changed it yet.
+    expect(!await input.checkOutOfDate());
+    await fs.unlink(test_file_path);
+    // Removing a file is considered a modification
+    expect(await input.checkOutOfDate());
+    expect(false);
+  });
+
+  test('Plain file updating', async () => {
+    await fs.writeFile(test_file_path, 'dummy');
+    const input = await InputFile.create(test_file_path);
+    // Not modified yet:
+    expect(!await input.checkOutOfDate());
+    // Update file and check:
+    await fs.writeFile(test_file_path, 'dummy2');
+    expect(await input.checkOutOfDate());
+    // InputFile doesn't change its stat mtime:
+    expect(await input.checkOutOfDate());
+  });
+
+  test('Input file set maps files correctly', async () => {
+    const foo_subdir = path.join(here, 'foo');
+    const dummy_file = path.join(foo_subdir, 'dummy_file');
+    const fileset = await InputFileSet.create({
+      buildFiles: [{
+        isCMake: false,
+        isTemporary: false,
+        sources: [
+          'dummy_file',
+          foo_subdir,
+        ],
+      }],
+      cmakeRootDirectory: '', // unused
+      sourceDirectory: foo_subdir,
+    });
+    expect(fileset.inputFiles).to.have.lengthOf(2, 'Wrong file count');
+    // The relative path 'dummy_file' should have mapped to the full path to the correct file
+    expect(fileset.inputFiles[0].filePath).to.eq(dummy_file, 'Filepath mapped incorrectly');
+    // The absolute path `foo_subdir` should be kept as-is
+    expect(fileset.inputFiles[1].filePath).to.eq(foo_subdir, 'Filepath mapped incorrectly');
+    // Since the file doesn't exist, the fileset should tell us it is dirty
+    expect(await fileset.checkOutOfDate());
+  });
+});

--- a/test/unit-tests/index.ts
+++ b/test/unit-tests/index.ts
@@ -10,6 +10,8 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
+require('module-alias/register');
+
 // tslint:disable-next-line:no-var-keyword
 var testRunner = require('vscode/lib/testrunner');
 


### PR DESCRIPTION
CMake's dirty signal is a bit unreliable, but it does let us query all files
that are inputs to the build. We can use this information to implement
our own dirty checks.

This commit also tweaks some auto-saving so that we can be sure that
configure output is written to the terminal at the proper time. It also
moves auto-saving out of the driver logic into the business logic code.

[Fix #385], possibly?