### PR TITLE
Bugfix/reset progress when finished

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -516,6 +516,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       populateCollection(this._buildDiagnostics, file_diags);
       return rc === null ? -1 : rc;
     } finally {
+      this._statusBar.setStatusMessage('Ready');
       this._statusBar.setIsBusy(false);
       consumer.dispose();
     }

--- a/src/status.ts
+++ b/src/status.ts
@@ -186,6 +186,9 @@ export class StatusBar implements vscode.Disposable {
     if (this._isBusy) {
       this._buildButton.show();
     }
+    else{
+      this._progress = null;
+    }
   }
 
   /**


### PR DESCRIPTION
### This changes visible behavior

When building second time progress bar is shortly shown as 100%.
Resetting progress variable when build is finished assures that initial progress bar is set to 0%
