### PR TITLE
Bugfix/remove lowercase in diagnostic path

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -144,7 +144,7 @@ export class CMakeOutputConsumer implements OutputConsumer {
         };
         const vsdiag = new vscode.Diagnostic(new vscode.Range(lineno, 0, lineno, 9999), '', diagmap[level]);
         vsdiag.source = `CMake (${command})`;
-        const filepath = path.isAbsolute(filename) ? filename : util.normalizePath(path.join(this.sourceDir, filename));
+        const filepath = path.isAbsolute(filename) ? filename : util.normalizePath(path.join(this.sourceDir, filename), false);
         this._errorState.diag = {
           filepath,
           diag: vsdiag,
@@ -354,7 +354,7 @@ export class CompileOutputConsumer implements OutputConsumer {
   createDiagnostics(build_dir: string): FileDiagnostic[] {
     const diags_by_file = new Map<string, vscode.Diagnostic[]>();
 
-    const make_abs = (p: string) => util.normalizePath(path.isAbsolute(p) ? p : path.join(build_dir, p));
+    const make_abs = (p: string) => util.normalizePath(path.isAbsolute(p) ? p : path.join(build_dir, p), false);
     const severity_of = (p: string) => {
       switch (p) {
       case 'warning':

--- a/test/unit-tests/diagnostics.test.ts
+++ b/test/unit-tests/diagnostics.test.ts
@@ -20,14 +20,6 @@ function feedLines(consumer: OutputConsumer, output: string[], error: string[]) 
   }
 }
 
-function toLowerCaseForWindows(str: string): string {
-  if (process.platform == 'win32') {
-    return str.toLowerCase();
-  } else {
-    return str;
-  }
-}
-
 suite('Diagnostics', async () => {
   let consumer = new diags.CMakeOutputConsumer('dummyPath');
   let build_consumer = new diags.CompileOutputConsumer();
@@ -55,7 +47,7 @@ suite('Diagnostics', async () => {
     feedLines(consumer, [], error_output);
     expect(consumer.diagnostics.length).to.eq(1);
     const diag = consumer.diagnostics[0];
-    expect(diag.filepath).to.eq(toLowerCaseForWindows('dummyPath/CMakeLists.txt'));
+    expect(diag.filepath).to.eq('dummyPath/CMakeLists.txt');
     expect(diag.diag.severity).to.eq(vscode.DiagnosticSeverity.Warning);
     expect(diag.diag.source).to.eq('CMake (message)');
     expect(diag.diag.message).to.eq('I am a warning!');
@@ -144,7 +136,7 @@ suite('Diagnostics', async () => {
     expect(consumer.diagnostics.length).to.eq(2);
     const coll = vscode.languages.createDiagnosticCollection('cmake-tools-test');
     diags.populateCollection(coll, consumer.diagnostics);
-    const fullpath = toLowerCaseForWindows('dummyPath/CMakeLists.txt');
+    const fullpath = 'dummyPath/CMakeLists.txt';
     expect(coll.has(vscode.Uri.file(fullpath))).to.be.true;
     expect(coll.get(vscode.Uri.file(fullpath))!.length).to.eq(2);
   });


### PR DESCRIPTION
### This changes visible behavior

OS: windows

Path in diagnostic output are converted to lowercase. If there is name in path not in lowercase, when clicking on issue in "PROBLEMS" window vscode will open new editor window with same file just lowercase name.
