### PR TITLE
Feature/activation on workspace kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "onCommand:cmake.selectLaunchTarget",
     "onCommand:cmake.setVariant",
     "onCommand:cmake.stop",
-		"workspaceContains:CMakeLists.txt",
-		"workspaceContains:.vscode/cmake-kits.json"
+    "workspaceContains:CMakeLists.txt",
+    "workspaceContains:.vscode/cmake-kits.json"
   ],
   "main": "./out/src/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "onCommand:cmake.selectLaunchTarget",
     "onCommand:cmake.setVariant",
     "onCommand:cmake.stop",
-    "workspaceContains:CMakeLists.txt"
+		"workspaceContains:CMakeLists.txt",
+		"workspaceContains:.vscode/cmake-kits.json"
   ],
   "main": "./out/src/extension",
   "contributes": {


### PR DESCRIPTION
### This changes visible behavior

If there is no "${workspaceRoot}/CMakeLists.txt" (cmake.sourceDirectory is used) extension will not load automatically. As we now have "${workspaceRoot}.vscode/cmake-kits.json" we can activate extension on kit file also.