### PR TITLE
Fix and clean up cmake missing error message creation for #371

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -159,6 +159,23 @@
                 }
             }
             // "smartStep": true
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Backend tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "-u",
+                "tdd",
+                "--timeout",
+                "999999",
+                "--colors",
+                "-r",
+                "ts-node/register",
+                "${workspaceFolder}/test/backend-unit-tests/**/*.test.ts"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -690,6 +690,7 @@
     "clang-format": "^1.2.2",
     "mocha": "~3.4.2",
     "sinon": "^4.1.4",
+    "ts-node": "^6.0.0",
     "tslint": "^5.9.1",
     "typedoc": "^0.8.0",
     "typescript": "~2.3.0",

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -55,6 +55,8 @@ if (! $NoTest) {
     # Prepare to run our tests
     Invoke-TestPreparation -CMakePath $cmake_binary
 
+    Invoke-MochaTest "CMake Tools: Backend tests"
+
     Invoke-VSCodeTest "CMake Tools: Unit tests" `
         -TestsPath "$REPO_DIR/out/test/unit-tests" `
         -Workspace "$REPO_DIR/test/unit-tests/test-project-without-cmakelists"

--- a/scripts/cmt.psm1
+++ b/scripts/cmt.psm1
@@ -468,3 +468,24 @@ function Invoke-SmokeTest($Name) {
         -TestsPath "$repo_dir/out/test/extension-tests/$Name" `
         -Workspace "$repo_dir/test/extension-tests/$Name/project-folder"
 }
+
+function Invoke-MochaTest {
+    [CmdletBinding(PositionalBinding = $false)]
+    param(
+        # Description for the test
+        [Parameter(Position = 0, Mandatory)]
+        [string]
+        $Description
+    )
+    $ErrorActionPreference = "Stop"
+    $repo_dir = Split-Path $PSScriptRoot -Parent
+    $test_bin = Join-Path $repo_dir "/node_modules/mocha/bin/_mocha"
+    $test_runner_args = @(
+        $test_bin;
+        "--ui"; "tdd";
+        "-r"; "ts-node/register";
+        "${repo_dir}/test/backend-unit-tests/**/*.test.ts")
+
+    $test_runner_all_args = $test_runner_args -join ' '
+    Invoke-ChronicCommand "Executing VSCode test: $Description" @test_runner_args
+}

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -318,7 +318,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       log.debug('Not starting CMake driver: no kits defined');
       return null;
     }
-    const cmakePath = await paths.cmakePath;
+    let cmakePath = await paths.cmakePath;
+    if (cmakePath === null)
+      cmakePath = '';
     const cmake = await getCMakeExecutableInformation(cmakePath);
     if (!cmake.isPresent) {
       vscode.window.showErrorMessage(`Bad CMake executable "${

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1,6 +1,8 @@
 /**
  * Root of the extension
  */
+import {CMakeExecutable, getCMakeExecutableInformation} from '@cmt/cmake/cmake-executable';
+import {versionToString} from '@cmt/util';
 import * as http from 'http';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -9,7 +11,6 @@ import * as ws from 'ws';
 import * as api from './api';
 import {ExecutionOptions, ExecutionResult} from './api';
 import {CacheEditorContentProvider} from './cache-editor';
-import {CMakeExecutable, getCMakeExecutableInformation} from '@cmt/cmake/cmake_executable';
 import {CMakeServerClientDriver} from './cms-driver';
 import config from './config';
 import {CTestDriver} from './ctest';
@@ -180,8 +181,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (cmake.isServerModeSupported) {
         drv = await CMakeServerClientDriver.create(cmake, this._stateManager, kit);
       } else {
-        log.info(`CMake Server is not available with the current CMake executable. Please upgrade to CMake ${
-            cmake.minimalServerModeVersion} or newer.`);
+        log.warning(
+            `CMake Server is not available with the current CMake executable. Please upgrade to CMake
+            ${versionToString(cmake.minimalServerModeVersion)} or newer.`);
         drv = await LegacyCMakeDriver.create(cmake, this._stateManager, kit);
       }
     } else {
@@ -214,9 +216,8 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
   async executeCMakeCommand(args: string[], options?: ExecutionOptions): Promise<ExecutionResult> {
     const drv = await this.getCMakeDriverInstance();
-    const cmake = await paths.cmakePath;
     if (drv) {
-      return drv.executeCommand(cmake, args, undefined, options).result;
+      return drv.executeCommand(drv.cmake.path, args, undefined, options).result;
     } else {
       throw new Error('Unable to execute cmake command, there is no valid cmake driver instance.');
     }

--- a/src/cmake/cmake-executable.ts
+++ b/src/cmake/cmake-executable.ts
@@ -9,10 +9,10 @@ export interface CMakeExecutable {
   minimalServerModeVersion: util.Version;
 }
 
-export async function getCMakeExecutableInformation(path: string|null): Promise<CMakeExecutable> {
+export async function getCMakeExecutableInformation(path: string): Promise<CMakeExecutable> {
   const cmake = {path, isPresent: false, minimalServerModeVersion: util.parseVersion('3.7.1')} as CMakeExecutable;
 
-  if (path && path.length != 0) {
+  if (path.length != 0) {
     try {
       const version_ex = await proc.execute(path, ['--version']).result;
       if (version_ex.retc === 0 && version_ex.stdout) {

--- a/src/cmake/cmake_executable.ts
+++ b/src/cmake/cmake_executable.ts
@@ -1,0 +1,40 @@
+import * as proc from '../proc';
+import * as util from '../util';
+
+export interface CMakeExecutable {
+  path: string;
+  isPresent: boolean;
+  isServerModeSupported?: boolean;
+  version?: util.Version;
+  minimalServerModeVersion: util.Version;
+}
+
+export async function getCMakeExecutableInformation(path: string): Promise<CMakeExecutable> {
+  const cmake = {path, isPresent: false, minimalServerModeVersion: util.parseVersion('3.7.1')} as CMakeExecutable;
+
+  if( path.length != 0) {
+    try {
+        const version_ex = await proc.execute(path, ['--version']).result;
+        if (version_ex.retc === 0 && version_ex.stdout) {
+        cmake.isPresent = true;
+
+        console.assert(version_ex.stdout);
+        const version_re = /cmake version (.*?)\r?\n/;
+        cmake.version = util.parseVersion(version_re.exec(version_ex.stdout)![1]);
+
+        // We purposefully exclude versions <3.7.1, which have some major CMake
+        // server bugs
+        if (util.versionGreater(cmake.version, cmake.minimalServerModeVersion)) {
+            cmake.isServerModeSupported = true;
+        } else {
+            cmake.isServerModeSupported = false;
+        }
+        }
+    } catch (ex) {
+        if (ex.code != 'ENOENT') {
+        throw ex;
+        }
+    }
+  }
+  return cmake;
+}

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -1,12 +1,12 @@
+import {CMakeExecutable} from '@cmt/cmake/cmake-executable';
+import {InputFileSet} from '@cmt/dirty';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import {InputFileSet} from '@cmt/dirty';
 import * as api from './api';
 import {CacheEntryProperties, ExecutableTarget, RichTarget} from './api';
 import * as cache from './cache';
 import * as cms from './cms-client';
-import {CMakeExecutable} from '@cmt/cmake/cmake_executable';
 import config from './config';
 import {CMakeDriver} from './driver';
 import {Kit} from './kit';

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -56,9 +56,7 @@ export interface SiteData {
   Testing: TestingData;
 }
 
-export interface CTestResults {
-  Site: SiteData;
-}
+export interface CTestResults { Site: SiteData; }
 
 interface EncodedMeasurementValue {
   $: {encoding?: string; compression?: string;};
@@ -345,29 +343,29 @@ export class CTestDriver implements vscode.Disposable {
     log.showChannel();
     this._decorationManager.clearFailingTestDecorations();
 
-    const configuration = driver.currentBuildType;
     const ctestpath = await paths.ctestPath;
-    if (ctestpath) {
-      const child
-          = driver.executeCommand(ctestpath,
-                                  [`-j${config.numCTestJobs}`, '-C', configuration, '-T', 'test', '--output-on-failure']
-                                      .concat(config.ctestArgs),
-                                  new CTestOutputLogger(),
-                                  {environment: config.testEnvironment, cwd: driver.binaryDir});
-
-      const res = await child.result;
-      await this.reloadTests(driver);
-      if (res.retc === null) {
-        log.info('CTest run was terminated');
-        return -1;
-      } else {
-        log.info('CTest finished with return code', res.retc);
-      }
-      return res.retc;
-    } else {
+    if (ctestpath === null) {
       log.info('CTest path is not set');
       return -2;
     }
+
+    const configuration = driver.currentBuildType;
+    const child
+        = driver.executeCommand(ctestpath,
+                                [`-j${config.numCTestJobs}`, '-C', configuration, '-T', 'test', '--output-on-failure']
+                                    .concat(config.ctestArgs),
+                                new CTestOutputLogger(),
+                                {environment: config.testEnvironment, cwd: driver.binaryDir});
+
+    const res = await child.result;
+    await this.reloadTests(driver);
+    if (res.retc === null) {
+      log.info('CTest run was terminated');
+      return -1;
+    } else {
+      log.info('CTest finished with return code', res.retc);
+    }
+    return res.retc;
   }
 
   /**

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -2,15 +2,15 @@
  * Defines base class for CMake drivers
  */ /** */
 
-import * as path from 'path';
-import * as vscode from 'vscode';
+ import * as path from 'path';
+ import * as vscode from 'vscode';
 
-import * as api from './api';
-import config from './config';
-import * as expand from './expand';
-import {CMakeGenerator, CompilerKit, getVSKitEnvironment, Kit, kitChangeNeedsClean, ToolchainKit, VSKit} from './kit';
-import * as logging from './logging';
-import paths from './paths';
+ import * as api from './api';
+ import config from './config';
+ import {CMakeExecutable} from '@cmt/cmake/cmake_executable';
+ import * as expand from './expand';
+ import {CMakeGenerator, CompilerKit, getVSKitEnvironment, Kit, kitChangeNeedsClean, ToolchainKit, VSKit} from './kit';
+ import * as logging from './logging';
 import {fs} from './pr';
 import * as proc from './proc';
 import rollbar from './rollbar';
@@ -76,7 +76,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Construct the driver. Concrete instances should provide their own creation
    * routines.
    */
-  protected constructor(readonly stateManager: StateManager) {}
+  protected constructor(readonly cmake: CMakeExecutable, readonly stateManager: StateManager) {}
 
   /**
    * Dispose the driver. This disposes some things synchronously, but also
@@ -192,7 +192,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
   /**
    * Get the vscode root workspace folder.
    *
-   * @returns Returns the vscode root workspace folder. Returns `null` if no folder is open or the folder uri is not a `file://` scheme.
+   * @returns Returns the vscode root workspace folder. Returns `null` if no folder is open or the folder uri is not a
+   * `file://` scheme.
    */
   private get _workspaceRootPath() {
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders[0].uri.scheme !== 'file') {
@@ -718,7 +719,7 @@ Please install or configure a preferred generator, or update settings.json or yo
     const expanded_args = await Promise.all(expanded_args_promises);
     log.trace('CMake build args are: ', JSON.stringify(expanded_args));
 
-    const cmake = await paths.cmakePath;
+    const cmake = this.cmake.path;
     const child = this.executeCommand(cmake, expanded_args, consumer, {environment: build_env});
     this._currentProcess = child;
     this._isBusy = true;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -2,15 +2,15 @@
  * Defines base class for CMake drivers
  */ /** */
 
- import * as path from 'path';
- import * as vscode from 'vscode';
+import {CMakeExecutable} from '@cmt/cmake/cmake-executable';
+import * as path from 'path';
+import * as vscode from 'vscode';
 
- import * as api from './api';
- import config from './config';
- import {CMakeExecutable} from '@cmt/cmake/cmake_executable';
- import * as expand from './expand';
- import {CMakeGenerator, CompilerKit, getVSKitEnvironment, Kit, kitChangeNeedsClean, ToolchainKit, VSKit} from './kit';
- import * as logging from './logging';
+import * as api from './api';
+import config from './config';
+import * as expand from './expand';
+import {CMakeGenerator, CompilerKit, getVSKitEnvironment, Kit, kitChangeNeedsClean, ToolchainKit, VSKit} from './kit';
+import * as logging from './logging';
 import {fs} from './pr';
 import * as proc from './proc';
 import rollbar from './rollbar';
@@ -76,7 +76,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Construct the driver. Concrete instances should provide their own creation
    * routines.
    */
-  protected constructor(readonly cmake: CMakeExecutable, readonly stateManager: StateManager) {}
+  protected constructor(public readonly cmake: CMakeExecutable, readonly stateManager: StateManager) {}
 
   /**
    * Dispose the driver. This disposes some things synchronously, but also

--- a/src/legacy-driver.ts
+++ b/src/legacy-driver.ts
@@ -3,12 +3,12 @@
  * Can also talk to newer versions of CMake via the command line.
  */ /** */
 
- import * as path from 'path';
- import * as vscode from 'vscode';
+import {CMakeExecutable} from '@cmt/cmake/cmake-executable';
+import * as path from 'path';
+import * as vscode from 'vscode';
 
- import * as api from './api';
- import {CMakeCache} from './cache';
- import {CMakeExecutable} from '@cmt/cmake/cmake_executable';
+import * as api from './api';
+import {CMakeCache} from './cache';
 import {CompilationDatabase} from './compdb';
 import {CMakeDriver} from './driver';
 import {Kit} from './kit';

--- a/src/legacy-driver.ts
+++ b/src/legacy-driver.ts
@@ -3,17 +3,17 @@
  * Can also talk to newer versions of CMake via the command line.
  */ /** */
 
-import * as path from 'path';
-import * as vscode from 'vscode';
+ import * as path from 'path';
+ import * as vscode from 'vscode';
 
-import * as api from './api';
-import {CMakeCache} from './cache';
+ import * as api from './api';
+ import {CMakeCache} from './cache';
+ import {CMakeExecutable} from '@cmt/cmake/cmake_executable';
 import {CompilationDatabase} from './compdb';
 import {CMakeDriver} from './driver';
 import {Kit} from './kit';
 // import * as proc from './proc';
 import * as logging from './logging';
-import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
 import rollbar from './rollbar';
@@ -26,7 +26,7 @@ const log = logging.createLogger('legacy-driver');
  * The legacy driver.
  */
 export class LegacyCMakeDriver extends CMakeDriver {
-  private constructor(state: StateManager) { super(state); }
+  private constructor(cmake: CMakeExecutable, state: StateManager) { super(cmake, state); }
 
   private _needsReconfigure = true;
   get needsReconfigure() { return this._needsReconfigure; }
@@ -52,14 +52,13 @@ export class LegacyCMakeDriver extends CMakeDriver {
   // Legacy disposal does nothing
   async asyncDispose() { this._cacheWatcher.dispose(); }
 
-  async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer):
-      Promise<number> {
+  async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer): Promise<number> {
     // Dup args so we can modify them
     const args = Array.from(args_);
     args.push('-H' + util.normalizePath(this.sourceDir));
     const bindir = util.normalizePath(this.binaryDir);
     args.push('-B' + bindir);
-    const cmake = await paths.cmakePath;
+    const cmake = this.cmake.path;
     log.debug('Invoking CMake', cmake, 'with arguments', JSON.stringify(args));
     const env = await this.getConfigureEnvironment();
     const res = await this.executeCommand(cmake, args, outputConsumer, {environment: env}).result;
@@ -102,9 +101,9 @@ export class LegacyCMakeDriver extends CMakeDriver {
     });
   }
 
-  static async create(state: StateManager, kit: Kit|null): Promise<LegacyCMakeDriver> {
+  static async create(cmake: CMakeExecutable, state: StateManager, kit: Kit|null): Promise<LegacyCMakeDriver> {
     log.debug('Creating instance of LegacyCMakeDriver');
-    return this.createDerived(new LegacyCMakeDriver(state), kit);
+    return this.createDerived(new LegacyCMakeDriver(cmake, state), kit);
   }
 
   get targets() { return []; }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -65,13 +65,17 @@ class Paths {
   }
 
   get cmakePath(): Promise<string|null> { return this._getCMakePath(); }
-  get ctestPath(): Promise<string> { return this._getCTestPath(); }
+  get ctestPath(): Promise<string|null> { return this._getCTestPath(); }
 
-  private async _getCTestPath(): Promise<string> {
+  private async _getCTestPath(): Promise<string|null> {
     const ctest_path = config.raw_ctestPath;
     if (!ctest_path || ctest_path == 'auto') {
       const cmake = await this.cmakePath;
-      return path.join(path.dirname(cmake!), 'ctest');
+      if (cmake === null) {
+        return null;
+      } else {
+        return path.join(path.dirname(cmake), 'ctest');
+      }
     } else {
       return ctest_path;
     }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -95,8 +95,7 @@ class Paths {
             }
           }
         }
-        // We've got nothing...
-        throw new Error('No CMake found on $PATH');
+        return '';
       }
       return on_path;
     }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -64,20 +64,20 @@ class Paths {
     });
   }
 
-  get cmakePath(): Promise<string> { return this._getCMakePath(); }
+  get cmakePath(): Promise<string|null> { return this._getCMakePath(); }
   get ctestPath(): Promise<string> { return this._getCTestPath(); }
 
   private async _getCTestPath(): Promise<string> {
     const ctest_path = config.raw_ctestPath;
     if (!ctest_path || ctest_path == 'auto') {
       const cmake = await this.cmakePath;
-      return path.join(path.dirname(cmake), 'ctest');
+      return path.join(path.dirname(cmake!), 'ctest');
     } else {
       return ctest_path;
     }
   }
 
-  private async _getCMakePath(): Promise<string> {
+  private async _getCMakePath(): Promise<string|null> {
     const raw = config.raw_cmakePath;
     if (raw == 'auto' || raw == 'cmake') {
       // We start by searching $PATH for cmake
@@ -95,7 +95,7 @@ class Paths {
             }
           }
         }
-        return '';
+        return null;
       }
       return on_path;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -240,6 +240,8 @@ export function versionGreater(lhs: Version, rhs: Version|string): boolean {
   return false;
 }
 
+export function versionToString(ver: Version): string { return `${ver.major}.${ver.minor}.${ver.patch}`; }
+
 export function* flatMap<In, Out>(rng: Iterable<In>, fn: (item: In) => Iterable<Out>): Iterable<Out> {
   for (const elem of rng) {
     const mapped = fn(elem);

--- a/test/backend-unit-tests/cmake/cmake-executeable.test.ts
+++ b/test/backend-unit-tests/cmake/cmake-executeable.test.ts
@@ -3,6 +3,8 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 
+// tslint:disable:no-unused-expression
+
 suite('cmake-executeable', () => {
   test('Teste', () => {
     expect(true).to.be.true;

--- a/test/backend-unit-tests/cmake/cmake-executeable.test.ts
+++ b/test/backend-unit-tests/cmake/cmake-executeable.test.ts
@@ -1,0 +1,10 @@
+import {expect} from 'chai';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+suite('cmake-executeable', () => {
+  test('Teste', () => {
+    expect(true).to.be.true;
+  });
+});

--- a/test/extension-tests/successful-build/test/cmake.test.ts
+++ b/test/extension-tests/successful-build/test/cmake.test.ts
@@ -1,0 +1,41 @@
+import {CMakeTools} from '@cmt/cmake-tools';
+import {clearExistingKitConfigurationFile, DefaultEnvironment, expect} from '@test/util';
+
+suite('cmake', async () => {
+  let cmt: CMakeTools;
+  let testEnv: DefaultEnvironment;
+
+  setup(async function(this: Mocha.IBeforeAndAfterContext) {
+    this.timeout(100000);
+
+    const build_loc = 'build';
+    const exe_res = 'output.txt';
+
+    testEnv = new DefaultEnvironment('test/extension-tests/successful-build/project-folder', build_loc, exe_res);
+    cmt = await CMakeTools.create(testEnv.vsContext);
+
+    // This test will use all on the same kit.
+    // No rescan of the tools is needed
+    // No new kit selection is needed
+    await clearExistingKitConfigurationFile();
+    await cmt.scanForKits();
+    await cmt.selectKit();
+
+    testEnv.projectFolder.buildDirectory.clear();
+  });
+
+  teardown(async function(this: Mocha.IBeforeAndAfterContext) {
+    this.timeout(30000);
+    await cmt.asyncDispose();
+    testEnv.teardown();
+  });
+
+  test('No cmake present message', async () => {
+    testEnv.setting.changeSetting('cmakePath', 'cmake3');
+    await cmt.allTargetName; // Using an cmaketools command which creates the instance once.
+
+    expect(testEnv.errorMessagesQueue.length).to.eql(1); // Expect only cmake error message
+    expect(testEnv.errorMessagesQueue[0])
+        .to.be.contains('Is it installed or settings contain the correct path (cmake.cmakePath)?');
+  }).timeout(60000);
+});


### PR DESCRIPTION
The cmake missing error message was
The cmake path variable had many dependency to other components.
This refactoring introduce a single interface which represents the
cmake executable. It provides all information about the
cmake executable (version, serverModeSupport, and paths).

This modification allows to make the cmake executable check
in one function, separate ui from check and reduces the hide
dependencies. This ensures that only a valid cmake path is used
in a consistent way inside the drivers.

- Add new function for version and file present check.
- Refactored drivers to use cmakeexecutable object for path access.
- Add error message on missing cmake.
- Avoid throwing exception in _getCMakePath()
- Reformat source code with node_modules clang-format (7.0.0)

### This changes visible behavior

![grafik](https://user-images.githubusercontent.com/21360085/39094893-9cc47094-4637-11e8-85ab-c426d4a30ba4.png)

