### PR TITLE
Set current working directory for cmake server (Fix for #390 and maybe #227)

### DIFF
--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -515,7 +515,7 @@ export class CMakeServerClient {
                                             params.environment as proc.EnvironmentVariables);
     const child = this._proc
         = child_proc.spawn(params.cmakePath, ['-E', 'server', '--experimental', `--pipe=${pipe_file}`], {
-            env: final_env,
+            env: final_env, cwd: params.binaryDir
           });
     log.debug(`Started new CMake Server instance with PID ${child.pid}`);
     child.stdout.on('data', this._onErrorData.bind(this));


### PR DESCRIPTION
## This change addresses item #390 and maybe #227

Inside visual studio code is a symbolic link like `/home/dev/tt/src/link_dummy` is 
always translated to a real path `/home/matze/tt/dummy`. 
This means I opened folder  `/home/dev/tt/src/link_dummy` but I am working and see only `/home/matze/tt/dummy/`. The extension it self works only on the  `/home/dev/tt/src/dummy`

The issue #390 and #227 report that the can not build and in the output are paths like `/home/dev/tt/src/link_dummy` shown. This output comes from the cmake server responses 
for cache and codemodel.

This modification moved the `cwd` from vscode cwd for the start of cmake server
inside of the build folder. With this modification the cmake server responses 
with the correct paths inside of the cache and codemode.

## Before modification 

```
...
{"key":"Test_BINARY_DIR","properties":{"HELPSTRING":"Value Computed by CMake"},"type":"STATIC","value":"/home/dev/tt/src/link_dummy/build"},{"key":"Test_SOURCE_DIR","properties":{"HELPSTRING":"Value Computed by CMake"},"type":"STATIC","value":"/home/dev/tt/src/link_dummy"}],"cookie":"0.6238713307262769","inReplyTo":"cache","type":"reply"}

[CMakeTools] 2018-04-22T15:07:46.434Z [debug] [cms-client] Sending message to cmake-server: {"type":"codemodel","cookie":"0.8115253173940464"}
[CMakeTools] 2018-04-22T15:07:46.436Z [debug] [cms-client] Received message from cmake-server: 
{"configurations":[{"name":"Debug","projects":[{"buildDirectory":"/home/dev/tt/src/link_dummy/build","name":"Test","sourceDirectory":"/home/dev/tt/src/link_dummy","targets":[{"buildDirectory":"/home/dev/tt/src/link_dummy/build","fileGroups":[{"isGenerated":true,"sources":["build/CMakeFiles/ExperimentalStart","build/CMakeFiles/ExperimentalStart.rule"]}],"fullName":"ExperimentalStart","name":"ExperimentalStart","sourceDirectory":"/home/dev/tt/src/link_dummy","type":"UTILITY"},
....
```
## After modification

```
...
{"key":"Test_BINARY_DIR","properties":{"HELPSTRING":"Value Computed by CMake"},"type":"STATIC","value":"/home/matze/tt/dummy/build"},{"key":"Test_SOURCE_DIR","properties":{"HELPSTRING":"Value Computed by CMake"},"type":"STATIC","value":"/home/matze/tt/dummy"}],"cookie":"0.8473860436221778","inReplyTo":"cache","type":"reply"}

[CMakeTools] 2018-04-22T15:17:04.770Z [debug] [cms-client] Sending message to cmake-server: {"type":"codemodel","cookie":"0.5686870111219122"}
[CMakeTools] 2018-04-22T15:17:04.774Z [debug] [cms-client] Received message from cmake-server: 
{"configurations":[{"name":"Debug","projects":[{"buildDirectory":"/home/matze/tt/dummy/build","name":"Test","sourceDirectory":"/home/matze/tt/dummy","targets":[{"artifacts":["/home/matze/tt/dummy/build/Test"],"buildDirectory":"/home/matze/tt/dummy/build","fileGroups":[{"compileFlags":"-g  ","isGenerated":false,"language":"CXX","sources":["main.cpp"]}],"fullName":"Test","linkFlags":"-rdynamic","linkLanguageFlags":"-g","linkerLanguage":"CXX","name":"Test","sourceDirectory":"/home/matze/tt/dummy","type":"EXECUTABLE"},{"buildDirectory":"/home/matze/tt/dummy/build","fileGroups":[{"isGenerated":true,"sources":["build/CMakeFiles/ContinuousSubmit","build/CMakeFiles/ContinuousSubmit.rule"]}],"fullName":"ContinuousSubmit","name":"ContinuousSubmit","sourceDirectory":"/home/matze/tt/dummy","type":"UTILITY"},
...
```
