### PR TITLE
In scanForKits allow for arm-none-eabi-gcc

### DIFF
--- a/scripts/cmt.psm1
+++ b/scripts/cmt.psm1
@@ -307,13 +307,14 @@ function Invoke-TestPreparation {
     $ext = if ($PSVersionTable.Platform -eq "Unix") { "" } else { ".exe" }
     $in_binary = (Get-ChildItem $fakebin_build -Recurse -Filter "FakeOutputGenerator$ext").FullName
 
-    $targets = @("clang-0.25", "gcc-42.1", "gcc-666", "clang-8.1.0")
+    $cfg_dir = Join-Path -Path $fakebin_src -ChildPath "configfiles"
+    $targets = Get-ChildItem -Path $cfg_dir -File | ForEach-Object { $_.BaseName }
 
     foreach ($target in $targets) {
         Copy-Item $in_binary "$fakebin_dest/$target$ext"
     }
 
-    Copy-Item $fakebin_src/configfiles/* -Destination $fakebin_dest -Recurse
+    Copy-Item $cfg_dir/* -Destination $fakebin_dest -Recurse
 
 }
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -139,7 +139,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCo
       return null;
     }
     const version = version_match[1];
-    const gxx_fname = fname.replace(/^gcc/, 'g++');
+    const gxx_fname = fname.replace(/gcc/, 'g++');
     const gxx_bin = path.join(path.dirname(bin), gxx_fname);
     const name = `GCC ${version}`;
     log.debug('Detected GCC compiler kit:', bin);

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -324,7 +324,7 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
 
   const vs_installs = JSON.parse(vswhere_res.stdout) as VSInstallation[];
   for (const inst of vs_installs) {
-    if ((inst_ids.indexOf(inst.instanceId) < 0) && (inst.displayName)) {
+    if (inst_ids.indexOf(inst.instanceId) < 0) {
       installs.push(inst);
       inst_ids.push(inst.instanceId);
     }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -118,7 +118,7 @@ type MaybeCompilerKitPr = Promise<CompilerKit|null>;
 export async function kitIfCompiler(bin: string, pr?: ProgressReporter): MaybeCompilerKitPr {
   const fname = path.basename(bin);
   // Check by filename what the compiler might be. This is just heuristic.
-  const gcc_regex = /^gcc(-\d+(\.\d+(\.\d+)?)?)?(\.exe)?$/;
+  const gcc_regex = /^((\w+-)*)gcc(-\d+(\.\d+(\.\d+)?)?)?(\.exe)?$/;
   const clang_regex = /^clang(-\d+(\.\d+(\.\d+)?)?)?(\.exe)?$/;
   const gcc_res = gcc_regex.exec(fname);
   const clang_res = clang_regex.exec(fname);

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -84,7 +84,7 @@ const DEFAULT_WINDOWS_KITS: KitEnvironment[] = DEFAULT_VS_KITS.concat(DEFAULT_CY
 
 const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
   ['win32']: DEFAULT_WINDOWS_KITS.concat(
-      [{defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: ['c:\\cygwin64\\bin']}]),
+      [{defaultKit: 'Clang 5.0.1', expectedDefaultGenerator: 'Unix Makefiles', path: [' C:\\Program Files\\LLVM\\bin']}]),
   ['Visual Studio 2017']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2017 Preview']: DEFAULT_WINDOWS_KITS,
   ['Visual Studio 2015']: DEFAULT_WINDOWS_KITS,

--- a/test/fakeOutputGenerator/configfiles/cross-compile-gcc.cfg
+++ b/test/fakeOutputGenerator/configfiles/cross-compile-gcc.cfg
@@ -1,0 +1,4 @@
+Im not a real cross compiler
+But CMake Tools will parse my output
+and believe that I am
+gcc version 0.2.1000 (not real)

--- a/test/unit-tests/kit-scan.test.ts
+++ b/test/unit-tests/kit-scan.test.ts
@@ -112,14 +112,14 @@ suite('Kits scan test', async () => {
       await fs.mkdir(path_with_compilername);
       // Scan the directory with fake compilers in it
       const kits = await kit.scanDirForCompilerKits(fakebin);
-      expect(kits.length).to.eq(3);
+      expect(kits.length).to.eq(4);
     });
 
     test('Scan file with compiler name', async () => {
       await fs.writeFile(path_with_compilername, '');
       // Scan the directory with fake compilers in it
       const kits = await kit.scanDirForCompilerKits(fakebin);
-      expect(kits.length).to.eq(3);
+      expect(kits.length).to.eq(4);
     });
   });
 
@@ -212,7 +212,7 @@ suite('Kits scan test', async () => {
 
       const kitFile = await readValidKitFile(path_rescan_kit);
       const nonVSKits = kitFile.filter(item => item.visualStudio == null);
-      expect(nonVSKits.length).to.be.eq(3);
+      expect(nonVSKits.length).to.be.eq(4);
     }).timeout(10000);
 
     test('check check combination of scan and old kits', async () => {

--- a/test/unit-tests/kit-scan.test.ts
+++ b/test/unit-tests/kit-scan.test.ts
@@ -56,6 +56,15 @@ suite('Kits scan test', async () => {
     expect(compkit!.name).to.eq('GCC 42.1');
   });
 
+  test('Detect a GCC cross compiler compiler file', async () => {
+    const compiler = path.join(fakebin, 'cross-compile-gcc');
+    const compkit = await kit.kitIfCompiler(compiler);
+    expect(compkit).to.not.be.null;
+    expect(compkit!.compilers).has.property('C').equal(compiler);
+    expect(compkit!.compilers).to.not.have.property('CXX');
+    expect(compkit!.name).to.eq('GCC 0.2.1000');
+  });
+
   test('Detect a Clang compiler file', async () => {
     const compiler = path.join(fakebin, 'clang-0.25');
     const compkit = await kit.kitIfCompiler(compiler);

--- a/test/unit-tests/kit-scan.test.ts
+++ b/test/unit-tests/kit-scan.test.ts
@@ -62,7 +62,7 @@ suite('Kits scan test', async () => {
     expect(compkit).to.not.be.null;
     expect(compkit!.compilers).has.property('C').equal(compiler);
     expect(compkit!.compilers).to.not.have.property('CXX');
-    expect(compkit!.name).to.eq('GCC 0.2.1000');
+    expect(compkit!.name).to.eq('GCC for cross-compile 0.2.1000');
   });
 
   test('Detect a Clang compiler file', async () => {


### PR DESCRIPTION
## This change addresses item #402

### This changes scanForKit 

The following changes are proposed:

- Scan for kits allows for a target triple prefixing gcc in the binary name.
