### PR TITLE
Make sure ci.ps1 is running in powershell 6

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -12,6 +12,10 @@ param(
 )
 $ErrorActionPreference = "Stop"
 
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    Write-Error -Message "This script requires at least powershell 6"
+}
+
 $CMakeToolsVersion = "0.11.0"
 
 # Import the utility modules


### PR DESCRIPTION
ci.ps1 uses built in variables which are only present in powershell 6. $PSVersionTable does not have an os entry in powershell version 5. This will cause ci.ps1 to break in cryptic ways.

This adds quick break to the powershell script if its running on an old version of powershell.
