### PR TITLE
Add search compiler in mingw dir

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -25,11 +25,16 @@ import {fs} from './pr';
 import rollbar from './rollbar';
 import {StatusBar} from './status';
 import {VariantManager} from './variant';
+import paths from '@cmt/paths';
 
 const open = require('open') as ((url: string, appName?: string, callback?: Function) => void);
 
 const log = logging.createLogger('main');
 const build_log = logging.createLogger('build');
+
+function convertMingwDirsToSearchPaths( mingwDirs : string[]) : string[] {
+  return mingwDirs.map( mingwDir => path.join(mingwDir, 'bin'));
+}
 
 /**
  * Class implementing the extension. It's all here!
@@ -109,7 +114,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    * It's up to the kit manager to do all things related to kits. Has two-phase
    * init.
    */
-  private readonly _kitManager = new KitManager(this.workspaceContext.state);
+  private readonly _kitManager = new KitManager(this.workspaceContext.state, convertMingwDirsToSearchPaths(this.workspaceContext.config.mingwSearchDirs));
 
   /**
    * The variant manager keeps track of build variants. Has two-phase init.

--- a/test/unit-tests/kit-scan.test.ts
+++ b/test/unit-tests/kit-scan.test.ts
@@ -132,7 +132,7 @@ suite('Kits scan test', async () => {
       sandbox = sinon.sandbox.create();
       const stateMock = sandbox.createStubInstance(state.StateManager);
       sandbox.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
-      km = new kit.KitManager(stateMock, path_rescan_kit);
+      km = new kit.KitManager(stateMock, [], path_rescan_kit);
 
       // Mock showInformationMessage to suppress needed user choice
       sandbox.stub(vscode.window, 'showInformationMessage')

--- a/test/unit-tests/kitmanager.test.ts
+++ b/test/unit-tests/kitmanager.test.ts
@@ -29,7 +29,7 @@ suite('Kits test', async () => {
       const stateMock = gui_sandbox.createStubInstance(state.StateManager);
       sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
       const kit_file = getTestResourceFilePath('test_kit.json');
-      km = new kit.KitManager(stateMock, kit_file);
+      km = new kit.KitManager(stateMock, [], kit_file);
     });
     teardown(async () => { gui_sandbox.restore(); });
 
@@ -56,7 +56,7 @@ suite('Kits test', async () => {
     const stateMock = sinon.createStubInstance(state.StateManager);
     let storedActivatedKitName: string = '';
     sinon.stub(stateMock, 'activeKitName').get(() => null).set(kit_ => storedActivatedKitName = kit_);
-    const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
+    const km = new kit.KitManager(stateMock, [], getTestResourceFilePath('test_kit.json'));
     await km.initialize();
     // Check that each time we change the kit, it fires a signal
     let fired_kit: string|null = null;
@@ -76,7 +76,7 @@ suite('Kits test', async () => {
   test('KitManager test load of kit from test file', async () => {
     const stateMock = sinon.createStubInstance(state.StateManager);
     sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
-    const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
+    const km = new kit.KitManager(stateMock, [], getTestResourceFilePath('test_kit.json'));
 
     await km.initialize();
 
@@ -97,7 +97,7 @@ suite('Kits test', async () => {
     const stateMock = sinon.createStubInstance(state.StateManager);
 
     sinon.stub(stateMock, 'activeKitName').get(() => 'ToolchainKit 1').set(() => {});
-    const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
+    const km = new kit.KitManager(stateMock, [], getTestResourceFilePath('test_kit.json'));
 
     await km.initialize();
 
@@ -112,7 +112,7 @@ suite('Kits test', async () => {
     const stateMock = sinon.createStubInstance(state.StateManager);
     sinon.stub(stateMock, 'activeKitName').get(() => null).set(() => {});
 
-    const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
+    const km = new kit.KitManager(stateMock, [], getTestResourceFilePath('test_kit.json'));
     await km.initialize();
 
     expect(km.activeKit).to.be.null;
@@ -124,7 +124,7 @@ suite('Kits test', async () => {
     let storedActivatedKitName = 'not replaced';
     sinon.stub(stateMock, 'activeKitName').get(() => 'Unknown').set(kit_ => storedActivatedKitName = kit_);
 
-    const km = new kit.KitManager(stateMock, getTestResourceFilePath('test_kit.json'));
+    const km = new kit.KitManager(stateMock, [], getTestResourceFilePath('test_kit.json'));
     await km.initialize();
 
     expect(km.activeKit).to.be.null;


### PR DESCRIPTION
## This change addresses item #413

### This changes behavior

The following changes are proposed:

- Add generic approach to add additional search path for kit scan

- [ ] Unit tests
- [ ] Integration tests