### PR TITLE
Add default build system to ci tests scripts

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -74,6 +74,12 @@ Invoke-ChronicCommand "Running TSLint" $yarn run lint:nofix
 # Get the CMake binary that we will use to run our tests
 $cmake_binary = Install-TestCMake -Version "3.10.0"
 
+# Get the Ninja binary that we will use to run our tests
+$ninja_binary = Install-TestNinjaMakeSystem -Version "1.8.2"
+
+# Add Ninja to path variable of system
+Add_EnvPath ((get-item $ninja_binary).Directory.Parent.FullName)
+
 if (! $NoTest) {
     # Prepare to run our tests
     Invoke-TestPreparation -CMakePath $cmake_binary

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -77,8 +77,8 @@ $cmake_binary = Install-TestCMake -Version "3.10.0"
 # Get the Ninja binary that we will use to run our tests
 $ninja_binary = Install-TestNinjaMakeSystem -Version "1.8.2"
 
-# Add Ninja to path variable of system
-Add_EnvPath ((get-item $ninja_binary).Directory.Parent.FullName)
+# Add ninja to search path environment variable
+$Env:PATH = $Env:PATH + [System.IO.Path]::PathSeparator + (get-item $ninja_binary).Directory.FullName
 
 if (! $NoTest) {
     # Prepare to run our tests

--- a/scripts/cmt.psm1
+++ b/scripts/cmt.psm1
@@ -86,27 +86,6 @@ function Invoke-ExternalCommand {
     }
 }
 
-function Add_EnvPath {
-    [CmdletBinding()]
-    param(
-        # Path to add to process environment path
-        [Parameter(Mandatory)]
-        [string]
-        $Path
-    )
-
-    $tmp_path = [System.Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Process);
-    $separator = ":";
-    if ($PSVersionTable.OS.StartsWith("Microsoft Windows")) {
-        $separator = ";"
-    }
-
-    $tmp_path = $Path + $separator + $tmp_path;
-
-    [System.Environment]::SetEnvironmentVariable('Path',$tmp_path,[System.EnvironmentVariableTarget]::Process);
-
-}
-
 function Invoke-ChronicCommand {
     [CmdletBinding()]
     param(

--- a/test/extension-tests/successful-build/test/configure-and-build.test.ts
+++ b/test/extension-tests/successful-build/test/configure-and-build.test.ts
@@ -42,7 +42,7 @@ suite('Build', async () => {
 
     const result = await testEnv.result.getResultAsJson();
     expect(result['cookie']).to.eq('passed-cookie');
-  }).timeout(60000);
+  }).timeout(100000);
 
 
   test('Configure and Build', async () => {
@@ -51,7 +51,7 @@ suite('Build', async () => {
 
     const result = await testEnv.result.getResultAsJson();
     expect(result['cookie']).to.eq('passed-cookie');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Configure and Build run target', async () => {
     expect(await cmt.configure()).to.be.eq(0);
@@ -66,7 +66,7 @@ suite('Build', async () => {
     const resultFile = new TestProgramResult(testEnv.projectFolder.buildDirectory.location, 'output_target.txt');
     const result = await resultFile.getResultAsJson();
     expect(result['cookie']).to.eq('passed-cookie');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Test setting watcher', async () => {
     expect(testEnv.wsContext.config.buildDirectory).to.be.eq('${workspaceRoot}/build');

--- a/test/extension-tests/successful-build/test/configure-and-build.test.ts
+++ b/test/extension-tests/successful-build/test/configure-and-build.test.ts
@@ -67,12 +67,4 @@ suite('Build', async () => {
     const result = await resultFile.getResultAsJson();
     expect(result['cookie']).to.eq('passed-cookie');
   }).timeout(100000);
-
-  test('Test setting watcher', async () => {
-    expect(testEnv.wsContext.config.buildDirectory).to.be.eq('${workspaceRoot}/build');
-    testEnv.config.updatePartial({buildDirectory: 'Hallo'});
-    expect(testEnv.wsContext.config.buildDirectory).to.be.eq('Hallo');
-    testEnv.config.updatePartial({buildDirectory: '${workspaceRoot}/build'});
-    expect(testEnv.wsContext.config.buildDirectory).to.be.eq('${workspaceRoot}/build');
-  });
 });

--- a/test/extension-tests/successful-build/test/configure-and-build.test.ts
+++ b/test/extension-tests/successful-build/test/configure-and-build.test.ts
@@ -35,7 +35,7 @@ suite('Build', async () => {
     expect(await cmt.configure()).to.be.eq(0);
 
     expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'no expected cache present');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Build', async () => {
     expect(await cmt.build()).to.be.eq(0);

--- a/test/extension-tests/successful-build/test/environment.test.ts
+++ b/test/extension-tests/successful-build/test/environment.test.ts
@@ -55,7 +55,7 @@ suite('[Environment]', async () => {
     expect(await cmt.build()).to.be.eq(0, '[configureEnvironment] build failed');
     const result = await testEnv.result.getResultAsJson();
     expect(result['configure-env']).to.eq('', '[configureEnvironment] env-var got passed to compiler');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Passing env-vars to the compiler but not to CMake', async () => {
     // Set fake settings
@@ -77,7 +77,7 @@ suite('[Environment]', async () => {
     const result = await testEnv.result.getResultAsJson();
     expect(result['build-env'])
         .to.eq(path.basename(testEnv.projectFolder.location), '[buildEnvironment] substitution incorrect');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Passing env-vars to CMake AND to the compiler', async () => {
     // Set fake settings
@@ -99,5 +99,5 @@ suite('[Environment]', async () => {
     expect(await cmt.build()).to.be.eq(0, '[environment] build failed');
     const result = await testEnv.result.getResultAsJson();
     expect(result['env']).to.eq(path.basename(testEnv.projectFolder.location), '[environment] substitution incorrect');
-  }).timeout(60000);
+  }).timeout(100000);
 });

--- a/test/extension-tests/successful-build/test/scan_kits.test.ts
+++ b/test/extension-tests/successful-build/test/scan_kits.test.ts
@@ -45,5 +45,5 @@ suite('[MinGW Tests]', async () => {
     const is_kit_MinGW_w64_present = kits.find(kit => kit.name.search(/x86_64-w64-mingw32/g) != -1) ? true : false;
     expect(is_kit_MinGW_present).to.be.true;
     expect(is_kit_MinGW_w64_present).to.be.true;
-  }).timeout(60000);
+  }).timeout(100000);
 });

--- a/test/extension-tests/successful-build/test/toolchain.test.ts
+++ b/test/extension-tests/successful-build/test/toolchain.test.ts
@@ -45,5 +45,5 @@ suite('[Toolchain Substitution]', async () => {
     expect(normalizePath(cacheEntry.as<string>()))
         .to.eq(normalizePath(testEnv.projectFolder.location.concat('/test-toolchain.cmake')),
                '[toolchain] substitution incorrect');
-  }).timeout(60000);
+  }).timeout(100000);
 });

--- a/test/extension-tests/successful-build/test/variable-substitution.test.ts
+++ b/test/extension-tests/successful-build/test/variable-substitution.test.ts
@@ -47,7 +47,7 @@ suite('[Variable Substitution]', async () => {
     expect(normalizePath(cacheEntry.as<string>()))
         .to.eq(normalizePath(testEnv.projectFolder.location), '[workspaceRoot] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[workspaceRoot] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution for "workspaceFolder"', async () => {
     // Set fake settings
@@ -64,7 +64,7 @@ suite('[Variable Substitution]', async () => {
     expect(normalizePath(cacheEntry.as<string>()))
         .to.eq(normalizePath(testEnv.projectFolder.location), '[workspaceFolder] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[workspaceFolder] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution for "buildType"', async () => {
     // Set fake settings
@@ -80,7 +80,7 @@ suite('[Variable Substitution]', async () => {
     expect(cacheEntry.key).to.eq('buildType', '[buildType] unexpected cache entry key name');
     expect(cacheEntry.as<string>()).to.eq('Debug', '[buildType] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[buildType] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution for "workspaceRootFolderName"', async () => {
     // Set fake settings
@@ -98,7 +98,7 @@ suite('[Variable Substitution]', async () => {
     expect(cacheEntry.as<string>())
         .to.eq(path.basename(testEnv.projectFolder.location), '[workspaceRootFolderName] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[workspaceRootFolderName] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution for "generator"', async () => {
     // Set fake settings
@@ -115,7 +115,7 @@ suite('[Variable Substitution]', async () => {
     const generator = cache.get('CMAKE_GENERATOR') as api.CacheEntry;
     expect(cacheEntry.as<string>()).to.eq(generator.as<string>(), '[generator] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[generator] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution for "projectName"', async () => {
     // Set fake settings
@@ -131,7 +131,7 @@ suite('[Variable Substitution]', async () => {
     expect(cacheEntry.key).to.eq('projectName', '[projectName] unexpected cache entry key name');
     expect(cacheEntry.as<string>()).to.eq('Unknown Project', '[projectName] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[projectName] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution for "userHome"', async () => {
     // Set fake settings
@@ -148,7 +148,7 @@ suite('[Variable Substitution]', async () => {
     const user_dir = process.platform === 'win32' ? process.env['HOMEPATH']! : process.env['HOME']!;
     expect(cacheEntry.as<string>()).to.eq(user_dir, '[userHome] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[userHome] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution for variant names', async () => {
     // Set fake settings
@@ -170,7 +170,7 @@ suite('[Variable Substitution]', async () => {
     expect(cacheEntry2.key).to.eq('otherVariant', '[otherVariant] unexpected cache entry key name');
     expect(cacheEntry2.as<string>()).to.eq('option1', '[otherVariant] substitution incorrect');
     expect(typeof cacheEntry2.value).to.eq('string', '[otherVariant] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 
   test('Check substitution within "cmake.installPrefix"', async () => {
     // Set fake settings
@@ -188,5 +188,5 @@ suite('[Variable Substitution]', async () => {
         .to.eq(normalizePath(testEnv.projectFolder.buildDirectory.location.concat('/dist')),
                '[cmakeInstallPrefix] substitution incorrect');
     expect(typeof cacheEntry.value).to.eq('string', '[cmakeInstallPrefix] unexpected cache entry value type');
-  }).timeout(60000);
+  }).timeout(100000);
 });

--- a/test/extension-tests/successful-build/test/variant-envs.test.ts
+++ b/test/extension-tests/successful-build/test/variant-envs.test.ts
@@ -44,5 +44,5 @@ suite('[Environment Variables in Variants]', async () => {
     expect(typeof cacheEntry.value).to.eq('string', '[variantEnv] unexpected cache entry value type');
     expect(cacheEntry.as<string>())
         .to.eq('0cbfb6ae-f2ec-4017-8ded-89df8759c502', '[variantEnv] incorrect environment variable');
-  }).timeout(60000);
+  }).timeout(100000);
 });

--- a/test/unit-tests/kit-scan.test.ts
+++ b/test/unit-tests/kit-scan.test.ts
@@ -46,7 +46,7 @@ suite('Kits scan test', async () => {
          await kit.scanForKits();
        })
       // Compiler detection can run a little slow
-      .timeout(12000);
+      .timeout(60000);
 
   test('Detect a GCC compiler file', async () => {
     const compiler = path.join(fakebin, 'gcc-42.1');


### PR DESCRIPTION
The test system needs a default preferred generator.
In the extension is Ninja the default build system.
With this commit ninja download and integrat into the ci test
environment is done. The modification is needed some
correction in tests.