### PR TITLE
Fix stdout encoding still not working

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -315,7 +315,7 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   const sys32_path = path.join(process.env.WINDIR as string, 'System32');
 
   const vswhere_args =
-      ['/c', `${sys32_path}\\chcp 65001 | "${vswhere_exe}" -all -format json -products * -legacy -prerelease`];
+      ['/c', `${sys32_path}\\chcp 65001>nul && "${vswhere_exe}" -all -format json -products * -legacy -prerelease`];
   const vswhere_res
       = await proc.execute(`${sys32_path}\\cmd.exe`, vswhere_args, null, {silent: true, encoding: 'utf8', shell: true})
             .result;


### PR DESCRIPTION
Just modified command args. Ignore `chcp` log message and use `&&` to concatenate commands instead of `|`.

## This change addresses item #220 

Failed to parse json generated by vswhere.

## The purpose of this change

Fix `chcp` not working #220 

## Other Notes/Information

Related PR: #356 
