### PR TITLE
Enable all successful extension tests again

### DIFF
--- a/test/extension-tests/successful-build/test/configure-and-build.test.ts
+++ b/test/extension-tests/successful-build/test/configure-and-build.test.ts
@@ -156,7 +156,7 @@ suite('Build', async () => {
     expect(result1['compiler']).to.eql(compiler[1].compiler);
   }).timeout(100000);
 
-  test.only('Test kit switch between different preferred generators and same compiler', async function(this: ITestCallbackContext) {
+  test('Test kit switch between different preferred generators and same compiler', async function(this: ITestCallbackContext) {
     // Select compiler build node dependent
     const os_compilers : {[osName: string]: { kitLabel:RegExp, generator: string}[]} = { ['linux']: [
       {kitLabel: /^Generator switch test GCC Make/, generator: 'Unix Makefiles' },


### PR DESCRIPTION
A older PR had an Only statment in the tests. This disable all tests. 
This PR removes it to enable the tests again. 