### PR TITLE
Add a strand to serialize operations that must be properly ordered.

### DIFF
--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -144,11 +144,11 @@ class RollbarController {
    * @param additional Additional data to log
    * @param func The block to call
    */
-  invokeAsync<T>(what: string, additional: object, func: () => Promise<T>): void;
-  invokeAsync<T>(what: string, func: () => Promise<T>): void;
-  invokeAsync<T>(what: string, additional: object, func?: () => Promise<T>): void {
+  invokeAsync<T>(what: string, additional: object, func: () => Thenable<T>): void;
+  invokeAsync<T>(what: string, func: () => Thenable<T>): void;
+  invokeAsync<T>(what: string, additional: object, func?: () => Thenable<T>): void {
     if (!func) {
-      func = additional as () => Promise<T>;
+      func = additional as () => Thenable<T>;
       additional = {};
     }
     log.trace(`Invoking async function [${func.name}] with Rollbar wrapping`, `[${what}]`);
@@ -178,11 +178,11 @@ class RollbarController {
     }
   }
 
-  takePromise<T>(what: string, additional: object, pr: Promise<T>): void {
-    pr.catch(e => {
-      this.exception('Unhandled Promise rejection: ' + what, e, additional);
-      throw e;
-    });
+  takePromise<T>(what: string, additional: object, pr: Thenable<T>): void {
+    pr.then(
+        () => {},
+        e => { this.exception('Unhandled Promise rejection: ' + what, e, additional); },
+    );
   }
 }
 

--- a/src/strand.ts
+++ b/src/strand.ts
@@ -1,0 +1,47 @@
+/**
+ * Module providing "strands," serialized execution in an asychronous world.
+ */ /** */
+
+ /**
+  * Provides serial execution for asynchronous code. Here are the semantics:
+  *
+  * `Strand` holds an internal execution queue of completion callbacks. Each
+  * call to `execute` will push to the queue. When a callback in the queue
+  * finishes with either an exception or a regular return, the next callback in
+  * the queue will be dispatched. Callbacks are not executed until all prior
+  * callbacks have run to completion.
+  */
+export class Strand {
+  private _tailPromise: Thenable<void> = Promise.resolve();
+
+  private _enqueue(fn: () => Promise<void>) {
+    this._tailPromise = this._tailPromise.then(
+        () => fn(),
+        () => fn(),
+    );
+  }
+
+  /**
+   * Enqueue a function for execution.
+   *
+   * Callbacks passed to `execute()` are always executed in order, and never
+   * started until the prior callbacks have executed.
+   *
+   * @param func The next completion callback
+   * @returns a Thenable that will resolve with the return value/exception of
+   * the enqueued function.
+   */
+  execute<T>(func: () => Thenable<T>): Thenable<T>;
+  execute<T>(func: () => Promise<T>): Thenable<T>;
+  execute<T>(func: () => T): Thenable<T>;
+  execute<Ret>(func: () => Ret): Thenable<Ret> {
+    return new Promise<Ret>((resolve, reject) => {
+      this._enqueue(async () => {
+        try {
+          const result = await func();
+          resolve(result);
+        } catch (e) { reject(e); }
+      });
+    });
+  }
+}

--- a/test/backend-unit-tests/cmake/strand.test.ts
+++ b/test/backend-unit-tests/cmake/strand.test.ts
@@ -1,0 +1,38 @@
+require('module-alias/register');
+
+import * as chai from 'chai';
+import {expect} from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
+
+import {Strand} from '@cmt/strand';
+
+function pause(time: number): Thenable<void> {
+  return new Promise(resolve => { setTimeout(() => resolve(), time); });
+}
+
+// tslint:disable:no-unused-expression
+
+suite('Running strands', () => {
+  test('Run a thing', async () => {
+    const arr: number[] = [];
+    const s = new Strand();
+    await s.execute(() => arr.push(12));
+    expect(arr).to.eql([12]);
+  });
+  test('Run in order', async () => {
+    const arr: number[] = [];
+    const s = new Strand();
+    await s.execute(() => arr.push(12));
+    const pr = s.execute(async () => {
+      await pause(500);
+      expect(arr).to.eql([12]);
+    });
+    const pr2 = s.execute(() => arr.push(24));
+    expect(arr).to.eql([12]);
+    await pr;
+    await pr2;
+    expect(arr).to.eql([12, 24]);
+  });
+});

--- a/test/extension-tests/successful-build/test/configure-and-build.test.ts
+++ b/test/extension-tests/successful-build/test/configure-and-build.test.ts
@@ -108,10 +108,10 @@ suite('Build', async () => {
   test('Test kit switch after missing preferred generator', async function(this: ITestCallbackContext) {
     // Select compiler build node dependent
     const os_compilers : {[osName: string]: { kitLabel:RegExp, compiler:string}[]} = { ['linux']: [
-      {kitLabel: /^GCC 4.8.4/, compiler:'GNU GCC/G++' },
-      {kitLabel: /^Clang 5.0.0/, compiler:'GNU GCC/G++' }],
+      {kitLabel: /^GCC \d/, compiler:'GNU GCC/G++' },
+      {kitLabel: /^Clang \d/, compiler:'Clang/LLVM' }],
       ['win32']: [
-      {kitLabel: /^GCC 4.8.1/, compiler:'GNU GCC/G++' },
+      {kitLabel: /^GCC \d/, compiler:'GNU GCC/G++' },
       {kitLabel: /^VisualStudio/, compiler:'Microsoft Visual Studio' }
     ]};
     if( !(workername in os_compilers)) this.skip();
@@ -131,13 +131,13 @@ suite('Build', async () => {
     expect(result1['compiler']).to.eql(compiler[1].compiler);
   }).timeout(100000);
 
-  test('Test kit switch between different preferred generators and compilers', async function(this: ITestCallbackContext) {
+  test.only('Test kit switch between different preferred generators and compilers', async function(this: ITestCallbackContext) {
     // Select compiler build node dependent
     const os_compilers : {[osName: string]: { kitLabel:RegExp, compiler:string}[]} = { ['linux']: [
-      {kitLabel: /^GCC 4.8.4/, compiler:'GNU GCC/G++' },
-      {kitLabel: /^Clang 5.0.0/, compiler:'GNU GCC/G++' }],
+      {kitLabel: /^GCC \d/, compiler:'GNU GCC/G++' },
+      {kitLabel: /^Clang \d/, compiler:'Clang/LLVM' }],
       ['win32']: [
-      {kitLabel: /^GCC 4.8.1/, compiler:'GNU GCC/G++' },
+      {kitLabel: /^GCC \d/, compiler:'GNU GCC/G++' },
       {kitLabel: /^VisualStudio/, compiler:'Microsoft Visual Studio' }
     ]};
     if( !(workername in os_compilers)) this.skip();


### PR DESCRIPTION
Certain operations must be ensured to not race. When the kit is being changed, don't let a build be started that will use the old kit.