### PR TITLE
vscode-cpptools CustomConfigurationProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
         "category": "CMake"
       },
       {
-        "command": "cmake.outline.cleanRebuild" ,
+        "command": "cmake.outline.cleanRebuild",
         "title": "Clean rebuild"
       },
       {
@@ -938,6 +938,7 @@
     "open": "0.0.5",
     "rimraf": "^2.5.4",
     "rollbar": "~2.2.8",
+    "vscode-cpptools": "^1.2.2",
     "which": "~1.3.0",
     "ws": "^1.1.1",
     "xml2js": "^0.4.17"

--- a/package.json
+++ b/package.json
@@ -798,6 +798,12 @@
           "description": "Copy compile_commands.json to this location after a successful configure",
           "scope": "resource"
         },
+        "cmake.configureOnOpen": {
+          "type": "boolean",
+          "default": null,
+          "description": "Automatically configure CMake project directories when they are opened",
+          "scope": "resource"
+        },
         "cmake.useCMakeServer": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -907,7 +907,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "lint": "node ./node_modules/tslint/bin/tslint -p . --fix",
     "lint:nofix": "node ./node_modules/tslint/bin/tslint -p .",
-    "docs": "node ./node_modules/typedoc/bin/typedoc --mode modules --excludeExternals --out build/docs/dev --readme none src/"
+    "docs": "node ./node_modules/typedoc/bin/typedoc --mode modules --excludeExternals --out build/docs/dev --readme none src/ typings/"
   },
   "devDependencies": {
     "@types/ajv": "^0.0.3",
@@ -945,6 +945,7 @@
     "rimraf": "^2.5.4",
     "rollbar": "~2.2.8",
     "vscode-cpptools": "^1.3.1",
+    "shlex": "^1.0.2",
     "which": "~1.3.0",
     "ws": "^1.1.1",
     "xml2js": "^0.4.17"

--- a/package.json
+++ b/package.json
@@ -938,7 +938,7 @@
     "open": "0.0.5",
     "rimraf": "^2.5.4",
     "rollbar": "~2.2.8",
-    "vscode-cpptools": "^1.2.2",
+    "vscode-cpptools": "^1.3.1",
     "which": "~1.3.0",
     "ws": "^1.1.1",
     "xml2js": "^0.4.17"

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -217,7 +217,7 @@ export interface CodeModelParams {}
 export interface CodeModelRequest extends CookiedMessage, CodeModelParams { type: 'codemodel'; }
 
 export interface CodeModelFileGroup {
-  language: string;
+  language?: string;
   compileFlags: string;
   includePath?: {path: string; isSystem?: boolean;}[];
   defines?: string[];

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,7 @@ export interface ExtensionConfigurationSettings {
   mingwSearchDirs: string[];
   emscriptenSearchDirs: string[];
   copyCompileCommands: string|null;
+  configureOnOpen: boolean|null;
   useCMakeServer: boolean;
   enableTraceLogging: boolean;
   loggingLevel: LogLevelKey;
@@ -183,6 +184,8 @@ export class ConfigurationReader implements vscode.Disposable {
 
   get ctestArgs(): string[] { return this.configData.ctestArgs; }
 
+  get configureOnOpen() { return this.configData.configureOnOpen; }
+
   get useCMakeServer(): boolean { return this.configData.useCMakeServer; }
 
   get numJobs(): number {
@@ -248,6 +251,7 @@ export class ConfigurationReader implements vscode.Disposable {
     mingwSearchDirs: new vscode.EventEmitter<string[]>(),
     emscriptenSearchDirs: new vscode.EventEmitter<string[]>(),
     copyCompileCommands: new vscode.EventEmitter<string|null>(),
+    configureOnOpen: new vscode.EventEmitter<boolean|null>(),
     useCMakeServer: new vscode.EventEmitter<boolean>(),
     enableTraceLogging: new vscode.EventEmitter<boolean>(),
     loggingLevel: new vscode.EventEmitter<LogLevelKey>(),

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -33,7 +33,7 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
 
   dispose() {}
 
-  private _fileIndex = new Map<string, cpt.SourceFileConfigurationItem>();
+  private readonly _fileIndex = new Map<string, cpt.SourceFileConfigurationItem>();
 
   private _buildConfigurationData(grp: cms.CodeModelFileGroup, opts: CodeModelParams): cpt.SourceFileConfiguration {
     const lang = grp.language || 'CXX';

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -7,11 +7,79 @@
 
 import {CMakeCache} from '@cmt/cache';
 import * as cms from '@cmt/cms-client';
+import {createLogger} from '@cmt/logging';
+import rollbar from '@cmt/rollbar';
 import * as util from '@cmt/util';
 import * as path from 'path';
+import * as shlex from 'shlex';
 import * as vscode from 'vscode';
 import * as cpt from 'vscode-cpptools';
-import rollbar from './rollbar';
+
+const log = createLogger('cpptools');
+
+type StandardVersion = 'c89'|'c99'|'c11'|'c++98'|'c++03'|'c++11'|'c++14'|'c++17';
+
+export interface CompileFlagInformation {
+  extraDefinitions: string[];
+  standard: StandardVersion;
+}
+
+export function parseCompileFlags(args: string[]): CompileFlagInformation {
+  const iter = args[Symbol.iterator]();
+  const extraDefinitions: string[] = [];
+  let standard: StandardVersion = 'c++17';
+  while (1) {
+    const {done, value} = iter.next();
+    if (done) {
+      break;
+    }
+    const lower = value.toLowerCase();
+    if (value === '-D' || value === '/D') {
+      // tslint:disable-next-line:no-shadowed-variable
+      const {done, value} = iter.next();
+      if (done) {
+        rollbar.error('Unexpected end of parsing command line arguments');
+        continue;
+      }
+      extraDefinitions.push(value);
+    } else if (value.startsWith('-D') || value.startsWith('/D')) {
+      const def = value.substring(2);
+      extraDefinitions.push(def);
+    } else if (value.startsWith('-std=') || lower.startsWith('-std:') || lower.startsWith('/std:')) {
+      const std = value.substring(5);
+      if (std.endsWith('++14') || std.endsWith('++1y')) {
+        standard = 'c++14';
+      } else if (std.endsWith('++17') || std.endsWith('++1z')) {
+        standard = 'c++17';
+      } else if (std.endsWith('++11') || std.endsWith('++0x')) {
+        standard = 'c++11';
+      } else if (std.endsWith('++2a')) {
+        // Not yet supported...
+      } else if (std.endsWith('++98')) {
+        standard = 'c++98';
+      } else if (std.endsWith('++03')) {
+        standard = 'c++03';
+      } else {
+        // GNU options from: https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html#C-Dialect-Options
+        if (/(c|gnu)(90|89|iso9899:(1990|199409))/.test(value)) {
+          standard = 'c89';
+        } else if (/(c|gnu)(99|9x|iso9899:(1999|199x))/.test(value)) {
+          standard = 'c99';
+        } else if (/(c|gnu)(11|1x|iso9899:2011)/.test(value)) {
+          standard = 'c11';
+        } else if (/(c|gnu)(17|18|iso9899:(2017|2018))/.test(value)) {
+          // Not supported by cpptools
+          // standardVersion = 'c17';
+          standard = 'c11';
+        } else {
+          log.warning('Unknown standard control flag: ', value);
+          standard = 'c++17';
+        }
+      }
+    }
+  }
+  return {extraDefinitions, standard};
+}
 
 /**
  * Type given when updating the configuration data stored in the file index.
@@ -78,26 +146,30 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
 
   /**
    * Create a source file configuration for the given file group.
-   * @param grp The file group from the code model to create config data for
+   * @param fileGroup The file group from the code model to create config data for
    * @param opts Index update options
    */
-  private _buildConfigurationData(grp: cms.CodeModelFileGroup, opts: CodeModelParams): cpt.SourceFileConfiguration {
+  private _buildConfigurationData(fileGroup: cms.CodeModelFileGroup,
+                                  opts: CodeModelParams): cpt.SourceFileConfiguration {
     // If the file didn't have a language, default to C++
-    const lang = grp.language || 'CXX';
+    const lang = fileGroup.language || 'CXX';
     // Try the group's language's compiler, then the C++ compiler, then the C compiler.
     const comp_cache = opts.cache.get(`CMAKE_${lang}_COMPILER`) || opts.cache.get('CMAKE_CXX_COMPILER')
         || opts.cache.get('CMAKE_C_COMPILER');
     // Try to get the path to the compiler we want to use
     const comp_path = comp_cache ? comp_cache.as<string>() : opts.clCompilerPath;
     if (!comp_path) {
-      rollbar.error('Unable to automatically determine compiler', {lang, fileGroup: grp});
+      rollbar.error('Unable to automatically determine compiler', {lang, fileGroup});
     }
     const is_msvc = comp_path && (path.basename(comp_path).toLocaleLowerCase() === 'cl.exe');
+    const flags = shlex.split(fileGroup.compileFlags);
+    const {standard, extraDefinitions} = parseCompileFlags(flags);
+    const defines = (fileGroup.defines || []).concat(extraDefinitions);
     return {
-      defines: grp.defines || [],
-      includePath: (grp.includePath || []).map(p => p.path),
+      defines,
+      standard,
+      includePath: (fileGroup.includePath || []).map(p => p.path),
       intelliSenseMode: is_msvc ? 'msvc-x64' : 'clang-x64',
-      standard: 'c++17',  // TODO: Switch on correct standard
       compilerPath: comp_path || undefined,
     };
   }

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -1,74 +1,131 @@
 /**
- * Module for vscode-cpptools integration
+ * Module for vscode-cpptools integration.
+ *
+ * This module uses the [vscode-cpptools API](https://www.npmjs.com/package/vscode-cpptools)
+ * to provide that extension with per-file configuration information.
  */ /** */
 
 import {CMakeCache} from '@cmt/cache';
 import * as cms from '@cmt/cms-client';
-import {Kit} from '@cmt/kit';
 import * as util from '@cmt/util';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as cpt from 'vscode-cpptools';
 import rollbar from './rollbar';
 
+/**
+ * Type given when updating the configuration data stored in the file index.
+ */
 export interface CodeModelParams {
+  /**
+   * The CMake Server codemodel message content. This is the important one.
+   */
   codeModel: cms.CodeModelContent;
-  kit: Kit;
+  /**
+   * The contents of the CMakeCache.txt, which also provides supplementary
+   * configuration information.
+   */
   cache: CMakeCache;
+  /**
+   * The path to `cl.exe`, if necessary. VS generators will need this property
+   * because the compiler path is not available via the `kit` nor `cache`
+   * property.
+   */
   clCompilerPath?: string|null;
 }
 
+/**
+ * The actual class that provides information to the cpptools extension. See
+ * the `CustomConfigurationProvider` interface for information on how this class
+ * should be used.
+ */
 export class CppConfigurationProvider implements cpt.CustomConfigurationProvider {
+  /** Our name visible to cpptools */
   readonly name = 'CMake Tools';
+  /** Out extension ID, visible to cpptools */
   readonly extensionId = 'vector-of-bool.cmake-tools';
 
-  getConfiguration(uri: vscode.Uri): cpt.SourceFileConfigurationItem|undefined {
+  /**
+   * Get the SourceFileConfigurationItem from the index for the given URI
+   * @param uri The configuration to get from the index
+   */
+  private _getConfiguration(uri: vscode.Uri): cpt.SourceFileConfigurationItem|undefined {
     const norm_path = util.normalizePath(uri.fsPath);
     return this._fileIndex.get(norm_path);
   }
 
-  async canProvideConfiguration(uri: vscode.Uri) { return !!this.getConfiguration(uri); }
+  /**
+   * Test if we are able to provide a configuration for the given URI
+   * @param uri The URI to look up
+   */
+  async canProvideConfiguration(uri: vscode.Uri) { return !!this._getConfiguration(uri); }
 
-  async provideConfigurations(uris: vscode.Uri[]) { return util.dropNulls(uris.map(u => this.getConfiguration(u))); }
+  /**
+   * Get the configurations for the given URIs. URIs for which we have no
+   * configuration are simply ignored.
+   * @param uris The file URIs to look up
+   */
+  async provideConfigurations(uris: vscode.Uri[]) { return util.dropNulls(uris.map(u => this._getConfiguration(u))); }
 
+  /** No-op */
   dispose() {}
 
+  /**
+   * Index of files to configurations, using the normalized path to the file
+   * as the key.
+   */
   private readonly _fileIndex = new Map<string, cpt.SourceFileConfigurationItem>();
 
+  /**
+   * Create a source file configuration for the given file group.
+   * @param grp The file group from the code model to create config data for
+   * @param opts Index update options
+   */
   private _buildConfigurationData(grp: cms.CodeModelFileGroup, opts: CodeModelParams): cpt.SourceFileConfiguration {
+    // If the file didn't have a language, default to C++
     const lang = grp.language || 'CXX';
     // Try the group's language's compiler, then the C++ compiler, then the C compiler.
-    const compiler = opts.cache.get(`CMAKE_${lang}_COMPILER`) || opts.cache.get('CMAKE_CXX_COMPILER') || opts.cache.get('CMAKE_C_COMPILER');
-    const compilerPath = compiler ? compiler.as<string>() : opts.clCompilerPath;
-    let is_msvc = false;
-    if (compilerPath) {
-      is_msvc = path.basename(compilerPath).toLocaleLowerCase() === 'cl.exe';
+    const comp_cache = opts.cache.get(`CMAKE_${lang}_COMPILER`) || opts.cache.get('CMAKE_CXX_COMPILER')
+        || opts.cache.get('CMAKE_C_COMPILER');
+    // Try to get the path to the compiler we want to use
+    const comp_path = comp_cache ? comp_cache.as<string>() : opts.clCompilerPath;
+    if (!comp_path) {
+      rollbar.error('Unable to automatically determine compiler', {lang, fileGroup: grp});
     }
-    if (!compilerPath) {
-      rollbar.error('Unable to automatically determine compiler', {lang, fileGroup: grp, kit: opts.kit});
-    }
+    const is_msvc = comp_path && (path.basename(comp_path).toLocaleLowerCase() === 'cl.exe');
     return {
       defines: grp.defines || [],
       includePath: (grp.includePath || []).map(p => p.path),
       intelliSenseMode: is_msvc ? 'msvc-x64' : 'clang-x64',
       standard: 'c++17',  // TODO: Switch on correct standard
-      compilerPath: compilerPath || undefined,
+      compilerPath: comp_path || undefined,
     };
   }
 
+  /**
+   * Update the configuration index for the files in the given file group
+   * @param sourceDir The source directory where the file group was defined. Used to resvolve
+   * relative paths
+   * @param grp The file group
+   * @param opts Index update options
+   */
   private _updateFileGroup(sourceDir: string, grp: cms.CodeModelFileGroup, opts: CodeModelParams) {
-    const config = this._buildConfigurationData(grp, opts);
+    const configuration = this._buildConfigurationData(grp, opts);
     for (const src of grp.sources) {
       const abs = path.isAbsolute(src) ? src : path.join(sourceDir, src);
       const abs_norm = util.normalizePath(abs);
       this._fileIndex.set(abs_norm, {
         uri: vscode.Uri.file(abs).toString(),
-        configuration: config,
+        configuration,
       });
     }
   }
 
-  pushCodeModel(opts: CodeModelParams) {
+  /**
+   * Update the file index and code model
+   * @param opts Update parameters
+   */
+  updateConfigurationData(opts: CodeModelParams) {
     for (const config of opts.codeModel.configurations) {
       for (const project of config.projects) {
         for (const target of project.targets) {

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -49,7 +49,7 @@ export function parseCompileFlags(args: string[]): CompileFlagInformation {
       const std = value.substring(5);
       if (std.endsWith('++14') || std.endsWith('++1y')) {
         standard = 'c++14';
-      } else if (std.endsWith('++17') || std.endsWith('++1z')) {
+      } else if (std.endsWith('++17') || std.endsWith('++1z') || std.endsWith('++latest')) {
         standard = 'c++17';
       } else if (std.endsWith('++11') || std.endsWith('++0x')) {
         standard = 'c++11';

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -60,7 +60,8 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
     const config = this._buildConfigurationData(grp, opts);
     for (const src of grp.sources) {
       const abs = path.isAbsolute(src) ? src : path.join(sourceDir, src);
-      this._fileIndex.set(abs, {
+      const abs_norm = util.normalizePath(abs);
+      this._fileIndex.set(abs_norm, {
         uri: vscode.Uri.file(abs).toString(),
         configuration: config,
       });

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -42,7 +42,7 @@ export interface CodeModelParams {
 export class CppConfigurationProvider implements cpt.CustomConfigurationProvider {
   /** Our name visible to cpptools */
   readonly name = 'CMake Tools';
-  /** Out extension ID, visible to cpptools */
+  /** Our extension ID, visible to cpptools */
   readonly extensionId = 'vector-of-bool.cmake-tools';
 
   /**
@@ -104,7 +104,7 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
 
   /**
    * Update the configuration index for the files in the given file group
-   * @param sourceDir The source directory where the file group was defined. Used to resvolve
+   * @param sourceDir The source directory where the file group was defined. Used to resolve
    * relative paths
    * @param grp The file group
    * @param opts Index update options

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -1,0 +1,78 @@
+/**
+ * Module for vscode-cpptools integration
+ */ /** */
+
+import {CMakeCache} from '@cmt/cache';
+import * as cms from '@cmt/cms-client';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as cpt from 'vscode-cpptools';
+
+import rollbar from './rollbar';
+
+export class CppConfigurationProvider implements cpt.CustomConfigurationProvider {
+  readonly name = 'CMake Tools';
+  readonly extensionId = 'vector-of-bool.cmake-tools';
+
+  async canProvideConfiguration(uri: vscode.Uri) { return this._fileIndex.has(uri.fsPath); }
+
+  async provideConfigurations(uris: vscode.Uri[]) { return uris.map(u => this._provideOne(u)); }
+
+  private _provideOne(uri: vscode.Uri): cpt.SourceFileConfigurationItem {
+    const item = this._fileIndex.get(uri.fsPath);
+    if (!item) {
+      // DIRTY LIES
+      return undefined as any as cpt.SourceFileConfigurationItem;
+      rollbar.error('Tried to provide cpptools config for file that we do not have in the index');
+      return {
+        uri: uri.toString(),
+        configuration: {
+          defines: [],
+          standard: 'c++17',
+          includePath: [],
+          intelliSenseMode: 'clang-x64',
+        },
+      };
+    }
+    return item;
+  }
+
+  dispose() {}
+
+  private _fileIndex = new Map<string, cpt.SourceFileConfigurationItem>();
+
+  private _buildConfigurationData(grp: cms.CodeModelFileGroup, cache: CMakeCache): cpt.SourceFileConfiguration {
+    const compiler = cache.get(`CMAKE_${grp.language}_COMPILER`);
+    const compilerPath = compiler ? compiler.value : undefined;
+    return {
+      defines: grp.defines || [],
+      includePath: (grp.includePath || []).map(p => p.path),
+      intelliSenseMode: 'clang-x64',  // TODO: Switch on correct mode
+      standard: 'c++17',              // TODO: Switch on correct standard
+      compilerPath,
+    };
+  }
+
+  private _updateFileGroup(sourceDir: string, grp: cms.CodeModelFileGroup, cache: CMakeCache) {
+    const config = this._buildConfigurationData(grp, cache);
+    for (const src of grp.sources) {
+      const abs = path.isAbsolute(src) ? src : path.join(sourceDir, src);
+      this._fileIndex.set(abs, {
+        uri: vscode.Uri.file(abs).toString(),
+        configuration: config,
+      });
+    }
+  }
+
+  pushCodeModel(cm: cms.CodeModelContent, cache: CMakeCache) {
+    for (const config of cm.configurations) {
+      for (const project of config.projects) {
+        for (const target of project.targets) {
+          for (const grp of target.fileGroups || []) {
+            this._updateFileGroup(target.sourceDirectory || '', grp, cache);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -337,7 +337,7 @@ class ExtensionManager implements vscode.Disposable {
       launchTargetName: cmt.launchTargetName,
     });
     if (this._cppToolsAPI && cmt.codeModel && cmt.activeKit) {
-      const cm = cmt.codeModel;
+      const codeModel = cmt.codeModel;
       const kit = cmt.activeKit;
       const cpptools = this._cppToolsAPI;
       rollbar.invokeAsync('Update code model for cpptools', {}, async () => {
@@ -350,12 +350,7 @@ class ExtensionManager implements vscode.Disposable {
         }
         const env = await effectiveKitEnvironment(kit);
         const clCompilerPath = await findCLCompilerPath(env);
-        this._configProvider.pushCodeModel({
-          cache,
-          kit,
-          codeModel: cm,
-          clCompilerPath,
-        });
+        this._configProvider.updateConfigurationData({cache, codeModel, clCompilerPath});
         cpptools.didChangeCustomConfiguration(this._configProvider);
       });
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,6 +199,9 @@ class ExtensionManager implements vscode.Disposable {
     this._kitsWatcher.dispose();
     this._editorWatcher.dispose();
     this._projectOutlineDisposer.dispose();
+    if (this._cppToolsAPI) {
+      this._cppToolsAPI.dispose();
+    }
     // Dispose of each CMake Tools we still have loaded
     for (const cmt of this._cmakeToolsInstances.values()) {
       await cmt.asyncDispose();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1127,7 +1127,6 @@ export async function activate(context: vscode.ExtensionContext) {
 // this method is called when your extension is deactivated
 export async function deactivate() {
   log.debug('Deactivate CMakeTools');
-  //   outputChannels.dispose();
   if (_EXT_MANAGER) {
     await _EXT_MANAGER.asyncDispose();
   }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -10,8 +10,9 @@ import * as logging from './logging';
 import paths from './paths';
 import {fs} from './pr';
 import * as proc from './proc';
+import * as util from '@cmt/util';
 import {loadSchema} from './schema';
-import {compare, dropNulls, Ordering, thisExtensionPath} from './util';
+import {compare, dropNulls, Ordering, thisExtensionPath, objectPairs} from './util';
 
 const log = logging.createLogger('kit');
 
@@ -577,6 +578,41 @@ export async function getVSKitEnvironment(kit: Kit): Promise<Map<string, string>
     return null;
   }
   return varsForVSInstallation(requested, kit.visualStudioArchitecture!);
+}
+
+export async function effectiveKitEnvironment(kit: Kit): Promise<Map<string, string>> {
+  if (kit.visualStudio && kit.visualStudioArchitecture) {
+    const vs_vars = await getVSKitEnvironment(kit);
+    if (vs_vars) {
+      return vs_vars;
+    }
+  }
+  const host_env = objectPairs(process.env) as [string, string][];
+  return new Map(host_env);
+}
+
+export async function findCLCompilerPath(env: Map<string, string>): Promise<string | null> {
+  const path_var = util.find(env.entries(), ([key, _val]) => key.toLocaleLowerCase() === 'path');
+  if (!path_var) {
+    return null;
+  }
+  const path_ext_var = util.find(env.entries(), ([key, _val]) => key.toLocaleLowerCase() === 'pathext');
+  if (!path_ext_var) {
+    return null;
+  }
+  const path_val = path_var[1];
+  const path_ext = path_ext_var[1];
+  for (const dir of path_val.split(';')) {
+    for (const ext of path_ext.split(';')) {
+      const fname = `cl${ext}`;
+      const testpath = path.join(dir, fname);
+      const stat = await fs.tryStat(testpath);
+      if (stat && !stat.isDirectory()) {
+        return testpath;
+      }
+    }
+  }
+  return null;
 }
 
 export interface KitScanOptions {

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -39,6 +39,20 @@ export const rename = promisify(fs_.rename);
 
 export const stat = promisify(fs_.stat);
 
+/**
+ * Try and stat() a file. If stat() fails for *any reason*, returns `null`.
+ * @param filePath The file to try and stat()
+ */
+export async function tryStat(filePath: fs_.PathLike): Promise<fs_.Stats|null> {
+  try {
+    return await stat(filePath);
+  } catch (_e) {
+    // Don't even bother with the error. Any number of things might have gone
+    // wrong. Probably one of: Non-existing file, bad permissions, bad path.
+    return null;
+  }
+}
+
 export const readlink = promisify(fs_.readlink);
 
 export const unlink = promisify(fs_.unlink);

--- a/src/util.ts
+++ b/src/util.ts
@@ -114,6 +114,16 @@ export function reduce<In, Out>(iter: Iterable<In>, init: Out, mapper: (acc: Out
   return init;
 }
 
+export function find<T>(iter: Iterable<T>, predicate: (value: T) => boolean): T | undefined {
+  for (const value of iter) {
+    if (predicate(value)) {
+      return value;
+    }
+  }
+  // Nothing found
+  return undefined;
+}
+
 /**
  * Generate a random integral value.
  * @param min Minimum value

--- a/src/util.ts
+++ b/src/util.ts
@@ -318,7 +318,9 @@ export function thisExtension() {
 
 export function thisExtensionPath(): string { return thisExtension().extensionPath; }
 
-export function dropNulls<T>(items: (T|null)[]): T[] { return items.filter(item => item !== null) as T[]; }
+export function dropNulls<T>(items: (T|null|undefined)[]): T[] {
+  return items.filter(item => (item !== null && item !== undefined)) as T[];
+}
 
 export enum Ordering {
   Greater,

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -38,6 +38,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
     mingwSearchDirs: [],
     emscriptenSearchDirs: [],
     copyCompileCommands: null,
+    configureOnOpen: null,
     useCMakeServer: true,
     enableTraceLogging: false,
     loggingLevel: 'info',

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -3,7 +3,7 @@ import {expect} from '@test/util';
 
 // tslint:disable:no-unused-expression
 
-suite.only('CppTools tests', () => {
+suite('CppTools tests', () => {
   test('Parse some compiler flags', () => {
     let info = parseCompileFlags(['-DFOO=BAR']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -1,0 +1,18 @@
+import {parseCompileFlags} from '@cmt/cpptools';
+import {expect} from '@test/util';
+
+// tslint:disable:no-unused-expression
+
+suite.only('CppTools tests', () => {
+  test('Parse some compiler flags', () => {
+    let info = parseCompileFlags(['-DFOO=BAR']);
+    expect(info.extraDefinitions).to.eql(['FOO=BAR']);
+    info = parseCompileFlags(['-D', 'FOO=BAR']);
+    expect(info.extraDefinitions).to.eql(['FOO=BAR']);
+    info = parseCompileFlags(['-DFOO=BAR', '/D', 'BAZ=QUX']);
+    expect(info.extraDefinitions).to.eql(['FOO=BAR', 'BAZ=QUX']);
+    expect(info.standard).to.eql('c++17');
+    info = parseCompileFlags(['-std=c++03']);
+    expect(info.standard).to.eql('c++03');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
             "@cmt/*": ["src/*"],
             "@test/*": ["test/*"]
         },
+        "typeRoots": [
+            "node_modules/@types",
+            "typings"
+        ],
         "sourceMap": true,
         "rootDir": ".",
         "strict": true,

--- a/typings/shlex.d.ts
+++ b/typings/shlex.d.ts
@@ -1,0 +1,4 @@
+declare module 'shlex' {
+  declare function quote(arg: string): string;
+  declare function split(command: string): string[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,6 +2258,10 @@ vinyl@^2.0.1, vinyl@^2.0.2:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
+vscode-cpptools@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-1.2.2.tgz#170d78372271954b52799e61fb76596de80ff252"
+
 vscode@1.1.17:
   version "1.1.17"
   resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.17.tgz#cc2a61731e925301f03f003c009cbf454022cd83"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,9 +2258,9 @@ vinyl@^2.0.1, vinyl@^2.0.2:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-cpptools@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-1.2.2.tgz#170d78372271954b52799e61fb76596de80ff252"
+vscode-cpptools@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-1.3.1.tgz#a032cdb3a92581f7e58f7fcbc775182e184851dc"
 
 vscode@1.1.17:
   version "1.1.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,6 +1694,10 @@ shelljs@^0.8.1:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+shlex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shlex/-/shlex-1.0.2.tgz#c3b906f22fed7256633779c9abb13bf86bebeca2"
+
 sinon@~5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.0.7.tgz#3bded6a73613ccc9e512e20246ced69a27c27dab"


### PR DESCRIPTION
## At long last!

This PR introduces the long-`await`ed feature to automatically configure vscode-cpptools with information from CMake.

This change uses the new cpptools extension API to hook into that extension and give it information about the project's source files.

@bobbrow would you take a look and remind me if I've forgotten anything important?