### PR TITLE
Feature/kit variable

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -249,6 +249,9 @@ using ``${variable}`` syntax. The following built-in variables are expanded:
 ``${buildType}``
     The current CMake build type, eg. ``Debug``, ``Release``, ``MinSizeRel``
 
+``${buildKit}``
+    The current CMake kit name, eg. ``GCC 7.3.0``
+
 ``${generator}``
     The name of the CMake generator, eg. ``Ninja``
 

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -192,7 +192,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       workspaceRootFolderName: path.basename(ws_root),
       generator: this.generatorName || 'null',
       userHome: user_dir,
-      buildKit: this._kit!.name,
+      buildKit: this._kit ? this._kit.name : '__unknownkit__',
       // DEPRECATED EXPANSION: Remove this in the future:
       projectName: 'ProjectName',
     };

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -192,6 +192,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       workspaceRootFolderName: path.basename(ws_root),
       generator: this.generatorName || 'null',
       userHome: user_dir,
+      buildKit: this._kit!.name,
       // DEPRECATED EXPANSION: Remove this in the future:
       projectName: 'ProjectName',
     };
@@ -270,7 +271,12 @@ export abstract class CMakeDriver implements vscode.Disposable {
    */
   async setKit(kit: Kit): Promise<void> {
     log.info(`Switching to kit: ${kit.name}`);
-    const needs_clean = kitChangeNeedsClean(kit, this._kit);
+
+    const opts = this.expansionOptions;
+    opts.vars.buildKit = kit.name;
+    const newBinaryDir = util.normalizePath(await expand.expandString(this.ws.config.buildDirectory, opts));
+
+    const needs_clean = this.binaryDir === newBinaryDir && kitChangeNeedsClean(kit, this._kit);
     await this.doSetKit(needs_clean, async () => { await this._setKit(kit); });
   }
 

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -22,6 +22,7 @@ export interface RequiredExpansionContextVars {
   workspaceRoot: string;
   workspaceFolder: string;
   buildType: string;
+  buildKit: string;
   workspaceRootFolderName: string;
   generator: string;
   userHome: string;

--- a/test/extension-tests/successful-build/test/variable-substitution.test.ts
+++ b/test/extension-tests/successful-build/test/variable-substitution.test.ts
@@ -81,6 +81,23 @@ suite('[Variable Substitution]', async () => {
     expect(typeof cacheEntry.value).to.eq('string', '[buildType] unexpected cache entry value type');
   }).timeout(100000);
 
+  test('Check substitution for "buildKit"', async () => {
+    // Set fake settings
+    testEnv.config.updatePartial({configureSettings: {buildKit: '${buildKit}'}});
+
+    // Configure
+    expect(await cmt.configure()).to.be.eq(0, '[buildKit] configure failed');
+    expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache not present');
+    const cache = await CMakeCache.fromPath(await cmt.cachePath);
+
+    const cacheEntry = cache.get('buildKit') as api.CacheEntry;
+    expect(cacheEntry.type).to.eq(api.CacheEntryType.String, '[buildKit] unexpected cache entry type');
+    expect(cacheEntry.key).to.eq('buildKit', '[buildKit] unexpected cache entry key name');
+    const kit = cmt.activeKit;
+    expect(cacheEntry.as<string>()).to.eq(kit!.name, '[buildKit] substitution incorrect');
+    expect(typeof cacheEntry.value).to.eq('string', '[buildKit] unexpected cache entry value type');
+  }).timeout(100000);
+
   test('Check substitution for "workspaceRootFolderName"', async () => {
     // Set fake settings
     testEnv.config.updatePartial({configureSettings: {workspaceRootFolderName: '${workspaceRootFolderName}'}});


### PR DESCRIPTION
## This change addresses items #383 and #462

### This changes expansion variables, documentation

The following changes are proposed:

- Add a new expansion variable `${buildKit}`, which is the name of the current kit.
- If switching kits changes the binary directory, do not clean when switching kits.
