### PR TITLE
Added option to show the log when building.

### DIFF
--- a/package.json
+++ b/package.json
@@ -891,6 +891,15 @@
             "fatal"
           ],
           "scope": "window"
+        },
+        "cmake.revealLog": {
+          "type": "string",
+          "default": "always",
+          "enum": [
+            "focus",
+            "always",
+            "never"
+          ]
         }
       }
     },

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -19,6 +19,7 @@ export enum LogLevel {
 }
 
 export type LogLevelKey = 'trace'|'debug'|'info'|'note'|'warning'|'error'|'fatal';
+type RevealLogKey = 'always'|'never'|'focus';
 
 /**
  * Get the name of a logging level
@@ -187,7 +188,7 @@ class SingletonLogger {
 
   clearOutputChannel(): void { this._channel.clear(); }
 
-  showChannel(): void { this._channel.show(); }
+  showChannel(preserveFocus?: boolean): void { this._channel.show(preserveFocus); }
 
   private static _inst: SingletonLogger|null = null;
 
@@ -212,7 +213,16 @@ class Logger {
 
   clearOutputChannel() { SingletonLogger.instance().clearOutputChannel(); }
 
-  showChannel() { SingletonLogger.instance().showChannel(); }
+  showChannel() {
+    const reveal_log = vscode.workspace.getConfiguration('cmake').get<RevealLogKey>('revealLog', 'always');
+
+    const should_show = (reveal_log !== 'never');
+    const should_focus = (reveal_log === 'focus');
+
+    if (should_show) {
+      SingletonLogger.instance().showChannel(!should_focus);
+    }
+  }
 }
 
 export function createLogger(tag: string) { return new Logger(tag); }


### PR DESCRIPTION
## This change addresses item #560

### This changes visible behavior

The following changes are proposed:

- The default has been changed to showing the log, but **not** focusing on it.
- Focusing on the log is still an option.
- It is also possible to do nothing.
- A potentially nice feature, but as of now not implemented, would be to only show the log when a warning/error/etc. occurs.

## Other Notes/Information

The option naming is not ideal, as this was hacked together in 5 minutes. Feel free to change it.
