### PR TITLE
Upgrade CppToolsApi to use V2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1018,7 +1018,7 @@
     "rimraf": "^2.5.4",
     "rollbar": "~2.2.8",
     "tmp": "^0.0.33",
-    "vscode-cpptools": "^1.3.1",
+    "vscode-cpptools": "^2.1.2",
     "which": "~1.3.0",
     "ws": "^1.1.1",
     "xml2js": "^0.4.17"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -405,7 +405,7 @@ class ExtensionManager implements vscode.Disposable {
     });
     rollbar.invokeAsync('Update code model for cpptools', {}, async () => {
       if (!this._cppToolsAPI) {
-        this._cppToolsAPI = await cpt.getCppToolsApi(cpt.Version.v1);
+        this._cppToolsAPI = await cpt.getCppToolsApi(cpt.Version.v2);
       }
       if (this._cppToolsAPI && cmt.codeModel && cmt.activeKit) {
         const codeModel = cmt.codeModel;
@@ -422,7 +422,11 @@ class ExtensionManager implements vscode.Disposable {
         const clCompilerPath = await findCLCompilerPath(env);
         this._configProvider.updateConfigurationData({cache, codeModel, clCompilerPath});
         await this.ensureCppToolsProviderRegistered();
-        cpptools.didChangeCustomConfiguration(this._configProvider);
+        if (cpptools.notifyReady) {
+          cpptools.notifyReady(this._configProvider);
+        } else {
+          cpptools.didChangeCustomConfiguration(this._configProvider);
+        }
       }
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,9 +2121,10 @@ vinyl@^2.0.1, vinyl@^2.0.2:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-cpptools@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-1.3.1.tgz#a032cdb3a92581f7e58f7fcbc775182e184851dc"
+vscode-cpptools@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-2.1.2.tgz#465d42c66850e877ee5a14574c9376ffca151968"
+  integrity sha512-oMx/wsLQM6NggnmWn4t8lIrt1K7Zpl5G34zxNu+J6KHGnCxBzc+NHnxXS1Vu1hLxGWwANAvdxr3mEcA2LMe7hQ==
 
 vscode@1.1.21:
   version "1.1.21"


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->


The following changes are proposed:

Implement canProvideBrowseConfiguration and provideBrowseConfiguration
And also use _cachedSourceFileConfiguration(the latest retrieved configuration) when _getConfiguration failed for specifc 
file URI.

## The purpose of this change
Currently,  code complete can not browse external include paths such as Qt and so on.
<!-- If not linked to an issue, describe the purpose of this change. Otherwise,
delete this section. -->

## Other Notes/Information

<!-- Write whatever you feel is relevant -->
