### PR TITLE
Fix bug #601 Problem with CMake:Execute current target without debugger

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1086,7 +1086,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     };
     if (process.platform == 'win32') {
       // Use cmd.exe on Windows
-      termOptions.shellPath = 'C:/Windows/System32/cmd.exe';
+      termOptions.shellPath = 'C:\\Windows\\System32\\cmd.exe';
     }
     if (!this._launchTerminal)
       this._launchTerminal = vscode.window.createTerminal(termOptions);

--- a/test/extension-tests/successful-build/project-folder/main.cpp
+++ b/test/extension-tests/successful-build/project-folder/main.cpp
@@ -1,6 +1,7 @@
+#include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <string>
-#include <cstdlib>
 
 #ifndef _CMAKE_VERSION
     #define _CMAKE_VERSION "0.0"
@@ -29,4 +30,9 @@ int main(int, char**) {
     std::cout << "  \"build-env\": \"" << get_env_var("_BUILD_ENV") << "\",\n";
     std::cout << "  \"env\": \"" << get_env_var("_ENV") << "\"\n";
     std::cout << "}\n";
+
+    std::ofstream ofs ("test.txt", std::ofstream::out);
+    ofs << "{\n";
+    ofs << "  \"cookie\": \"" CMT_COOKIE "\",\n";
+    ofs << "}\n";
 }

--- a/test/extension-tests/successful-build/test/debugger.test.ts
+++ b/test/extension-tests/successful-build/test/debugger.test.ts
@@ -107,7 +107,7 @@ suite('[Debug/Lauch interface]', async () => {
     expect(fs.existsSync(validPath)).to.be.false;
   }).timeout(60000);
 
-  test('Test lauch target', async () => {
+  test('Test launch target', async () => {
     testEnv.config.updatePartial({buildBeforeRun: false});
 
     const executablesTargets = await cmt.executableTargets;
@@ -128,7 +128,7 @@ suite('[Debug/Lauch interface]', async () => {
     expect(terminal!.name).of.be.eq('CMake/Launch');
 
     // Needed to get launch target result
-    await new Promise(res => setTimeout(res, 1000));
+    await new Promise(res => setTimeout(res, 3000));
 
     // Check that it is compiled as a new file
     expect(fs.existsSync(createdFileOnExecution)).to.be.true;

--- a/test/extension-tests/successful-build/test/debugger.test.ts
+++ b/test/extension-tests/successful-build/test/debugger.test.ts
@@ -2,6 +2,7 @@ import {CMakeTools} from '@cmt/cmake-tools';
 import {DefaultEnvironment, expect, getFirstSystemKit} from '@test/util';
 import sinon = require('sinon');
 import * as fs from 'fs';
+import * as path from 'path';
 
 // tslint:disable:no-unused-expression
 
@@ -105,4 +106,32 @@ suite('[Debug/Lauch interface]', async () => {
     // Check that it is compiled as a new file
     expect(fs.existsSync(validPath)).to.be.false;
   }).timeout(60000);
+
+  test('Test lauch target', async () => {
+    testEnv.config.updatePartial({buildBeforeRun: false});
+
+    const executablesTargets = await cmt.executableTargets;
+    expect(executablesTargets.length).to.be.not.eq(0);
+    await cmt.setLaunchTargetByName(executablesTargets[0].name);
+
+    const launchProgrammPath = await cmt.launchTargetPath();
+    expect(launchProgrammPath).to.be.not.null;
+
+    // Remove file if not exists
+    const createdFileOnExecution = path.join(testEnv.projectFolder.location, 'test.txt');
+    if (fs.existsSync(createdFileOnExecution)) {
+      fs.unlinkSync(createdFileOnExecution);
+    }
+
+    const terminal = await cmt.launchTarget();
+    expect(terminal).of.be.not.null;
+    expect(terminal!.name).of.be.eq('CMake/Launch');
+
+    // Needed to get launch target result
+    await new Promise(res => setTimeout(res, 1000));
+
+    // Check that it is compiled as a new file
+    expect(fs.existsSync(createdFileOnExecution)).to.be.true;
+  }).timeout(60000);
 });
+


### PR DESCRIPTION
Commandline shellPath with slash does not work, it needs a backslash.


## This change addresses item #601

### This changes visible behavior

The following changes are proposed:

- Replace `/` by `\\`

## The purpose of this change

Command "launchTarget" (Execute current target without debugger) should work again
