### PR TITLE
Make preferred Generator problem more visible

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -394,9 +394,10 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
                   }
                 });
           } else if (e instanceof NoGeneratorError) {
-            vscode.window.showErrorMessage(
-                `Unable to determine what CMake generator to use. ` +
-                `Please install or configure a preferred generator, or update settings.json or your Kit configuration.`);
+            const message = `Unable to determine what CMake generator to use. ` +
+            `Please install or configure a preferred generator, or update settings.json, your Kit configuration or PATH variable.`;
+            log.error(message, e);
+            vscode.window.showErrorMessage(message);
           } else {
             throw e;
           }

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -351,6 +351,7 @@ export class ServerError extends Error implements ErrorMessage {
 }
 
 export class NoGeneratorError extends Error {
+  message: string = 'No usable generator found.';
 }
 
 export class BadHomeDirectoryError extends Error {

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -473,13 +473,19 @@ export abstract class CMakeDriver implements vscode.Disposable {
     return null;
   }
 
+  private nullableStringToString (arg: string | null | undefined) : any {
+    return arg ? arg : 'empty';
+  }
+
   private async testHaveCommand(program: string, args: string[] = ['--version']): Promise<boolean> {
-    const child = this.executeCommand(program, args, undefined, {silent: true});
+    const child = this.executeCommand(program, args);
     try {
       const result = await child.result;
+      log.debug("Command version test return code ", (result.retc ? result.retc : 'empty'));
       return result.retc == 0;
     } catch (e) {
       const e2: NodeJS.ErrnoException = e;
+      log.debug("Command version test return code ", this.nullableStringToString(e2.code), this.nullableStringToString(e2.code));
       if (e2.code == 'ENOENT') {
         return false;
       }

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -474,18 +474,18 @@ export abstract class CMakeDriver implements vscode.Disposable {
   }
 
   private nullableStringToString (arg: string | null | undefined) : any {
-    return arg ? arg : 'empty';
+    return arg === null ? 'empty' : arg;
   }
 
   private async testHaveCommand(program: string, args: string[] = ['--version']): Promise<boolean> {
     const child = this.executeCommand(program, args);
     try {
       const result = await child.result;
-      log.debug("Command version test return code ", (result.retc ? result.retc : 'empty'));
+      log.debug("Command version test return code", (result.retc === null ? 'empty': result.retc));
       return result.retc == 0;
     } catch (e) {
       const e2: NodeJS.ErrnoException = e;
-      log.debug("Command version test return code ", this.nullableStringToString(e2.code), this.nullableStringToString(e2.code));
+      log.debug("Command version test return code", this.nullableStringToString(e2.code), this.nullableStringToString(e2.code));
       if (e2.code == 'ENOENT') {
         return false;
       }


### PR DESCRIPTION
## This change addresses item #570

### This changes changes behavior on problems with preferred generator selection

The following changes are proposed:

- Add output of test execution for getBestGenerator() to logfile by adding
  more debug information to `testHaveCommand()`
- Add information from error message to log file to make `NoGeneratorError` visible

