### PR TITLE
Explicitly setting VS compiler cores and BuildInParallel to true.

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -729,8 +729,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
         return ['-j', this.ws.config.numJobs.toString()];
       else if (gen.includes('Visual Studio'))
         return [
-          '/m',
-          '/property:GenerateFullPaths=true',
+          '/m:' + this.ws.config.numJobs.toString(),
+          '/p:BuildInParallel=true',
+          '/p:GenerateFullPaths=true',
         ];  // TODO: Older VS doesn't support these flags
       else
         return [];


### PR DESCRIPTION
CMake build command Explicitly setting VS compiler cores and BuildInParallel property to true.

The build command would look something like this:
```
cmake --build . --config Debug --target ALL_BUILD -- /m:10 /p:BuildInParallel=true /p:GenerateFullPaths=true
```

And would be more consistent with the way we set cores(i.e `-j 10`) when using any other generators that are not using the VS compiler.
