### PR TITLE
Additional commands

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -82,8 +82,8 @@ specifying a a command-based substitution in the appropriate field of
 ``launch.json``.
 
 Here is a minimal example of a ``launch.json`` that uses the
-``cmake.launchTargetPath`` to start a debugger on the active selected launch
-target:
+``cmake.launchTargetPath`` and ``cmake.launchTargetDirectory`` to start a debugger
+on the active selected launch target:
 
 .. code:: javascript
 
@@ -101,8 +101,10 @@ target:
                 "cwd": "${workspaceFolder}",
                 "environment": [
                     {
+                        // add the directory where our target was built to the PATHs
+                        // it gets resolved by CMake Tools:
                         "name": "PATH",
-                        "value": "$PATH:$HOME/some_path"
+                        "value": "$PATH:${command:cmake.launchTargetDirectory}"
                     },
                     {
                         "name": "OTHER_VALUE",
@@ -127,7 +129,7 @@ absolute path to the program to run.
 
 .. note::
     A successful :ref:`configure <configuring>` must be executed before
-    ``cmake.launchTargetPath`` will resolve correctly.
+    ``cmake.launchTargetPath`` and ``cmake.launchTargetDirectory`` will resolve correctly.
 
 Running Targets Without a Debugger
 **********************************

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onCommand:cmake.install",
     "onCommand:cmake.launchTarget",
     "onCommand:cmake.launchTargetPath",
+    "onCommand:cmake.launchTargetDirectory",
     "onCommand:cmake.quickStart",
     "onCommand:cmake.resetState",
     "onCommand:cmake.scanForKits",

--- a/src/api.ts
+++ b/src/api.ts
@@ -283,4 +283,9 @@ export interface CMakeToolsAPI extends Disposable {
    * Get the path to the active launch target
    */
   launchTargetPath(): Thenable<string|null>;
+
+  /**
+   * Get the directory to the active launch target
+   */
+  launchTargetDirectory(): Thenable<string|null>;
 }

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -948,6 +948,18 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     return executable.path;
   }
 
+  /**
+   * Implementation of `cmake.launchTargetDirectory`. It just calls launchTargetPath and
+   * extracts the directory form the result.
+   */
+  async launchTargetDirectory(): Promise<string|null> {
+    const targetPath = await this.launchTargetPath();
+    if (targetPath === null) {
+      return null;
+    }
+    return path.dirname(targetPath);
+  }
+
   async prepareLaunchTargetExecutable(name?: string): Promise<api.ExecutableTarget|null> {
     let chosen: api.ExecutableTarget;
     if (name) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1042,6 +1042,8 @@ class ExtensionManager implements vscode.Disposable {
 
   launchTargetPath() { return this.withCMakeTools(null, cmt => cmt.launchTargetPath()); }
 
+  launchTargetDirectory() { return this.withCMakeTools(null, cmt => cmt.launchTargetDirectory()); }
+
   debugTarget(name?: string) { return this.withCMakeTools(null, cmt => cmt.debugTarget(name)); }
 
   launchTarget(name?: string) { return this.withCMakeTools(null, cmt => cmt.launchTarget(name)); }
@@ -1102,11 +1104,11 @@ async function setup(context: vscode.ExtensionContext, progress: ProgressHandle)
 
   // List of functions that will be bound commands
   const funs: (keyof ExtensionManager)[] = [
-    'editKits',     'scanForKits',      'selectKit',        'cleanConfigure', 'configure',
-    'build',        'setVariant',       'install',          'editCache',      'clean',
-    'cleanRebuild', 'buildWithTarget',  'setDefaultTarget', 'ctest',          'stop',
-    'quickStart',   'launchTargetPath', 'debugTarget',      'launchTarget',   'selectLaunchTarget',
-    'resetState',   'viewLog',          'compileFile',
+    'editKits',           'scanForKits',      'selectKit',              'cleanConfigure', 'configure',
+    'build',              'setVariant',       'install',                'editCache',      'clean',
+    'cleanRebuild',       'buildWithTarget',  'setDefaultTarget',       'ctest',          'stop',
+    'quickStart',         'launchTargetPath', 'launchTargetDirectory',  'debugTarget',    'launchTarget',
+    'selectLaunchTarget', 'resetState',       'viewLog',                'compileFile',
     // 'toggleCoverageDecorations', // XXX: Should coverage decorations be revived?
   ];
 

--- a/test/extension-tests/successful-build/test/debugger.test.ts
+++ b/test/extension-tests/successful-build/test/debugger.test.ts
@@ -2,6 +2,7 @@ import {CMakeTools} from '@cmt/cmake-tools';
 import {DefaultEnvironment, expect, getFirstSystemKit} from '@test/util';
 import sinon = require('sinon');
 import * as fs from 'fs';
+import * as path from 'path';
 
 // tslint:disable:no-unused-expression
 
@@ -41,6 +42,15 @@ suite('[Debug/Lauch interface]', async () => {
     await cmt.setLaunchTargetByName(executablesTargets[0].name);
 
     expect(await cmt.launchTargetPath()).to.be.eq(executablesTargets[0].path);
+  });
+
+  test('Test launchTargetDirectory for use in other extensions or launch.json', async () => {
+    const executablesTargets = await cmt.executableTargets;
+    expect(executablesTargets.length).to.be.not.eq(0);
+
+    await cmt.setLaunchTargetByName(executablesTargets[0].name);
+
+    expect(await cmt.launchTargetDirectory()).to.be.eq(path.dirname(executablesTargets[0].path));
   });
 
   test('Test build on launch (default)', async () => {


### PR DESCRIPTION
## Changes

- add a new `cmake.launchTargetDirectory` command.

This allows to use variable substitution to get the active launch target's directory in launch configurations. It works like `cmake.launchTargetPath` but instead of the path to the file, it's the path to the directory containing it.

## Why

In almost any complex project, lots of additional files are built and usually output next to the main executable (configuration files, data, etc.) When debugging this kind of projects, we have to set the launch working directory to the directory containing all those files. And if we configured CMake build directory using `${builtType}` we're screwed : we have no way of automatically knowing what working directory we should use.

Until this patch, I used the `${input:...}` feature, but it's error prone, and a bit tedious. With this command, we can easily access the directory and the launch configurations are a lot simpler. Also debugging no longer requires any user interaction (well, except for actually hitting F5 :) )

## Notes

I updated the doc and added a unit test. It basically just uses the existing `launchTargetPath` command and just does a `path.dirname` on the result, so the changes are pretty trivial.

I hope you'll accept this request, it would really make our life easier :)

Regards,
Damien.