### PR TITLE
Fix wrong VS generator selection (#682)

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -560,8 +560,11 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
   log.debug(` InstanceId: ${inst.instanceId}`);
   log.debug(` InstallVersion: ${inst.installationVersion}`);
   if (version) {
-    const generatorName: string|undefined = VsGenerators[version[1]];
+    let generatorName: string|undefined = VsGenerators[version[1]];
     if (generatorName) {
+      if (/64/.test(arch)) {
+        generatorName += " Win64";
+      }
       log.debug(` Generator Present: ${generatorName}`);
       kit.preferredGenerator = {
         name: generatorName,


### PR DESCRIPTION
Fix the wrong selection of prefered generator on 64bit builds
with visual studio.

## This change addresses item (#682)

### This changes visible behavior

The following changes are proposed:

- Correct generation of preferred generators for Visual Studio Projects on Arch 64 Projects
