### PR TITLE
conditionally add install target

### DIFF
--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -248,6 +248,7 @@ export interface CodeModelProject {
   sourceDirectory: string;
   buildDirectory: string;
   targets: CodeModelTarget[];
+  hasInstallRule: boolean;
 }
 
 export interface CodeModelConfiguration {

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -248,7 +248,7 @@ export interface CodeModelProject {
   sourceDirectory: string;
   buildDirectory: string;
   targets: CodeModelTarget[];
-  hasInstallRule: boolean;
+  hasInstallRule?: boolean;
 }
 
 export interface CodeModelConfiguration {

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -165,7 +165,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
       filepath: 'A special target to build all available targets',
       targetType: 'META',
     }];
-    if(build_config.projects.some(project => project.hasInstallRule))
+    if(build_config.projects.some(project => (project.hasInstallRule)? project.hasInstallRule: false))
     {
       metaTargets.push({
         type: 'rich' as 'rich',

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -159,6 +159,21 @@ export class CMakeServerClientDriver extends CMakeDriver {
       log.error('Found no matching code model for the current build type. This shouldn\'t be possible');
       return [];
     }
+    const metaTargets = [{
+      type: 'rich' as 'rich',
+      name: this.allTargetName,
+      filepath: 'A special target to build all available targets',
+      targetType: 'META',
+    }];
+    if(build_config.projects.some(project => project.hasInstallRule))
+    {
+      metaTargets.push({
+        type: 'rich' as 'rich',
+        name: 'install',
+        filepath: 'A special target to install all available targets',
+        targetType: 'META',
+      });
+    }
     return build_config.projects.reduce<RichTarget[]>((acc, project) => acc.concat(project.targets.map(
                                                           t => ({
                                                             type: 'rich' as 'rich',
@@ -168,12 +183,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
                                                                 : 'Utility target',
                                                             targetType: t.type,
                                                           }))),
-                                                      [{
-                                                        type: 'rich' as 'rich',
-                                                        name: this.allTargetName,
-                                                        filepath: 'A special target to build all available targets',
-                                                        targetType: 'META',
-                                                      }]);
+                                                      metaTargets);
   }
 
   get executableTargets(): ExecutableTarget[] {


### PR DESCRIPTION
## This change addresses item #504
closes #504

### This changes visible behavior

The following changes are proposed:

Conditionally add an `install` meta target if there is a project that has an install rule.

## The purpose of this change

cmake-server does not give an install target in project targets.
